### PR TITLE
Limit info from get_user_from_token

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -27,11 +27,21 @@ def login():
 
 
 def get_user_from_token(token):
+    """Return username and role for a valid token.
+
+    The password field is intentionally omitted to avoid exposing
+    credentials. ``None`` is returned for invalid tokens or unknown users.
+    """
     username = TOKENS.get(token)
     if not username:
         return None
     user = USERS.get(username)
-    return {'username': username, **user} if user else None
+    if not user:
+        return None
+    return {
+        'username': username,
+        'role': user['role']
+    }
 
 
 def role_required(role):


### PR DESCRIPTION
## Summary
- add a docstring and ensure `get_user_from_token` only exposes username and role

## Testing
- `python -m py_compile backend/auth.py`
- `python -m py_compile backend/*.py` *(fails: invalid syntax in app.py)*

------
https://chatgpt.com/codex/tasks/task_e_683f506702e8832ab2079f1d9385ebff