### PR TITLE
Add role-specific dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,10 @@
 # Pharmacuz
 
-dqdva9-codex/summarize-pharmacuz-project-overview
-Pharmacuz is a sample repository to demonstrate a pharmaceutical distribution and inventory management system. The backend now exposes basic authentication with role-based APIs for different users.
+Pharmacuz is a sample repository to demonstrate a pharmaceutical distribution and inventory management system. The backend exposes basic authentication with role-based APIs for different users.
 
 ## Structure
 
 - `backend/` – Flask application exposing authenticated endpoints for manufacturer, CFA, and super stockist roles.
-=======
-Pharmacuz is a sample repository to demonstrate a pharmaceutical distribution and inventory management system. This repository currently contains a simple Flask backend skeleton and placeholder directories for a frontend implementation.
-
-## Structure
-
-- `backend/` – contains a basic Flask application with placeholder endpoints for products and batches.
- main
 - `frontend/` – reserved for the progressive web app (PWA) implementation.
 
 ## Getting Started
@@ -26,8 +18,10 @@ Pharmacuz is a sample repository to demonstrate a pharmaceutical distribution an
    python app.py
    ```
    The server will run on `http://localhost:5000`.
+   Visit this URL in your browser to see the login page served from
+   `frontend/index.html`.
+After logging in you will be redirected to `/dashboard` to see your role-specific features.
 
-dqdva9-codex/summarize-pharmacuz-project-overview
 2. **Authentication**:
    Send a POST request to `/login` with JSON body `{"username": "admin", "password": "adminpass"}` (or other demo users) to receive a token.
    Use this token in the `Authorization` header (`Bearer <token>`) for subsequent requests.
@@ -40,9 +34,11 @@ dqdva9-codex/summarize-pharmacuz-project-overview
    - `POST /super_stockist/requests` – create stock request (super stockist role)
    - `GET /super_stockist/requests` – list requests
 
-These endpoints illustrate how RBAC can be implemented. The data is stored in memory for demonstration purposes.
-=======
-2. **Explore**: The app exposes simple JSON-based routes to demonstrate inventory data retrieval and batch creation.
+Each role is presented with its own dashboard when logging in:
+   - **Manufacturer** – manage products you supply.
+   - **CFA** – record and review goods receipt notes.
+   - **Super Stockist** – create and view stock requests.
+
+These endpoints and dashboards illustrate how RBAC can be implemented. The data is stored in memory for demonstration purposes.
 
 Further development will include full CRUD operations, authentication, role-based access, and offline-ready capabilities for the PWA.
-main

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,12 +1,11 @@
-#dqdva9-codex/summarize-pharmacuz-project-overview
-from flask import Flask, jsonify
+from flask import Flask, jsonify, send_from_directory
 
 from auth import auth_bp
 from manufacturer import manufacturer_bp
 from cfa import cfa_bp
 from super_stockist import super_stockist_bp
 
-app = Flask(__name__)
+app = Flask(__name__, static_folder='../frontend', static_url_path='')
 
 # Register blueprints
 app.register_blueprint(auth_bp)
@@ -16,49 +15,13 @@ app.register_blueprint(super_stockist_bp, url_prefix='/super_stockist')
 
 @app.route('/')
 def index():
-    return jsonify({'message': 'Pharmacuz API'})
-=======
-from flask import Flask, jsonify, request
+    return send_from_directory(app.static_folder, 'index.html')
 
-app = Flask(__name__)
 
-# In-memory storage for demonstration purposes
-PRODUCTS = []
-BATCHES = []
-
-@app.route('/')
-def index():
-    return jsonify({"message": "Pharmacuz API"})
-
-@app.route('/products', methods=['GET', 'POST'])
-def products():
-    if request.method == 'POST':
-        data = request.json
-        if not data or 'name' not in data:
-            return jsonify({'error': 'Invalid product data'}), 400
-        product = {
-            'id': len(PRODUCTS) + 1,
-            'name': data['name'],
-        }
-        PRODUCTS.append(product)
-        return jsonify(product), 201
-    return jsonify(PRODUCTS)
-
-@app.route('/batches', methods=['GET', 'POST'])
-def batches():
-    if request.method == 'POST':
-        data = request.json
-        if not data or 'product_id' not in data or 'quantity' not in data:
-            return jsonify({'error': 'Invalid batch data'}), 400
-        batch = {
-            'id': len(BATCHES) + 1,
-            'product_id': data['product_id'],
-            'quantity': data['quantity'],
-        }
-        BATCHES.append(batch)
-        return jsonify(batch), 201
-    return jsonify(BATCHES)
- main
+@app.route('/dashboard')
+def dashboard_page():
+    """Serve the dashboard page for logged in users."""
+    return send_from_directory(app.static_folder, 'dashboard.html')
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -27,11 +27,21 @@ def login():
 
 
 def get_user_from_token(token):
+    """Return username and role for a valid token.
+
+    The password field is intentionally omitted to avoid exposing
+    credentials. ``None`` is returned for invalid tokens or unknown users.
+    """
     username = TOKENS.get(token)
     if not username:
         return None
     user = USERS.get(username)
-    return {'username': username, **user} if user else None
+    if not user:
+        return None
+    return {
+        'username': username,
+        'role': user['role']
+    }
 
 
 def role_required(role):

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Dashboard - Pharmacuz</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+    <div class="container py-5">
+        <h1 class="mb-4">Dashboard</h1>
+        <div id="welcome" class="alert alert-info"></div>
+
+        <div id="manufacturerSection" class="d-none">
+            <h2>Manufacturer Functions</h2>
+            <ul>
+                <li>Create new products</li>
+                <li>View all products</li>
+            </ul>
+        </div>
+
+        <div id="cfaSection" class="d-none">
+            <h2>CFA Functions</h2>
+            <ul>
+                <li>Record Goods Receipt Notes</li>
+                <li>View GRN records</li>
+            </ul>
+        </div>
+
+        <div id="superStockistSection" class="d-none">
+            <h2>Super Stockist Functions</h2>
+            <ul>
+                <li>Create stock requests</li>
+                <li>View request history</li>
+            </ul>
+        </div>
+
+        <button id="logout" class="btn btn-secondary mt-3">Logout</button>
+    </div>
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const token = localStorage.getItem('token');
+        const role = localStorage.getItem('role');
+        if (!token || !role) {
+            window.location.href = '/';
+            return;
+        }
+        document.getElementById('welcome').textContent = `Logged in as ${role}`;
+
+        // Show relevant dashboard section based on role
+        if (role === 'manufacturer') {
+            document.getElementById('manufacturerSection').classList.remove('d-none');
+        } else if (role === 'cfa') {
+            document.getElementById('cfaSection').classList.remove('d-none');
+        } else if (role === 'super_stockist') {
+            document.getElementById('superStockistSection').classList.remove('d-none');
+        }
+
+        document.getElementById('logout').addEventListener('click', function() {
+            localStorage.removeItem('token');
+            localStorage.removeItem('role');
+            window.location.href = '/';
+        });
+    });
+    </script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Pharmacuz Login</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+    <div class="container py-5">
+        <h1 class="mb-4">Pharmacuz</h1>
+        <form id="loginForm" class="card p-4 mx-auto" style="max-width: 400px;">
+            <div class="mb-3">
+                <label for="username" class="form-label">Username</label>
+                <input type="text" class="form-control" id="username" required>
+            </div>
+            <div class="mb-3">
+                <label for="password" class="form-label">Password</label>
+                <input type="password" class="form-control" id="password" required>
+            </div>
+            <button type="submit" class="btn btn-primary w-100">Login</button>
+        </form>
+        <div id="result" class="mt-3"></div>
+    </div>
+    <script>
+    document.getElementById('loginForm').addEventListener('submit', async function(e) {
+        e.preventDefault();
+        const username = document.getElementById('username').value;
+        const password = document.getElementById('password').value;
+        const resp = await fetch('/login', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({username, password})
+        });
+        const data = await resp.json();
+        const result = document.getElementById('result');
+        if (resp.ok) {
+            localStorage.setItem('token', data.token);
+            localStorage.setItem('role', data.role);
+            window.location.href = '/dashboard';
+        } else {
+            result.textContent = data.error || 'Login failed';
+        }
+    });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- document individual dashboards per role
- show manufacturer, CFA and super stockist features on the dashboard page
- mention in README that the root URL serves the login page
- clarify in README that successful login redirects to `/dashboard`

## Testing
- `python -m py_compile backend/auth.py`
- `python -m py_compile backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_683f506702e8832ab2079f1d9385ebff