### PR TITLE
[Backend] Initial DB and API integration

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,42 +1,28 @@
-f2igg8-codex/modify-get_user_from_token-to-return-username-and-role
 import os
- main
-from flask import Flask, jsonify, send_from_directory
+from flask import Flask, send_from_directory
+from flask_cors import CORS
 
-from auth import auth_bp
-from manufacturer import manufacturer_bp
-from cfa import cfa_bp
-from super_stockist import super_stockist_bp
-
-app = Flask(__name__, static_folder='../frontend', static_url_path='')
-
-# Register blueprints
-app.register_blueprint(auth_bp)
-app.register_blueprint(manufacturer_bp, url_prefix='/manufacturer')
-app.register_blueprint(cfa_bp, url_prefix='/cfa')
-app.register_blueprint(super_stockist_bp, url_prefix='/super_stockist')
-
-@app.route('/')
-def index():
-    return send_from_directory(app.static_folder, 'index.html')
- f2igg8-codex/modify-get_user_from_token-to-return-username-and-role
+from .models import db
+from .routes.auth import auth_bp
+from .routes.manufacturer import manufacturer_bp
+from .routes.cfa import cfa_bp
+from .routes.super_stockist import super_stockist_bp
 
 
+def create_app():
+    app = Flask(__name__, static_folder='../frontend', static_url_path='')
+    app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL', 'sqlite:///pharmacuz.db')
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    CORS(app)
+    db.init_app(app)
 
+    app.register_blueprint(auth_bp, url_prefix='/api/auth')
+    app.register_blueprint(manufacturer_bp, url_prefix='/api/manufacturer')
+    app.register_blueprint(cfa_bp, url_prefix='/api/cfa')
+    app.register_blueprint(super_stockist_bp, url_prefix='/api/super_stockist')
 
- main
- main
-@app.route('/dashboard')
-def dashboard_page():
-    """Serve the dashboard page for logged in users."""
-    return send_from_directory(app.static_folder, 'dashboard.html')
- f2igg8-codex/modify-get_user_from_token-to-return-username-and-role
+    @app.route('/')
+    def index():
+        return send_from_directory(app.static_folder, 'index.html')
 
- main
- main
- main
-
-if __name__ == '__main__':
-    # Allow overriding port via the PORT environment variable
-    port = int(os.environ.get('PORT', 5000))
-    app.run(debug=True, port=port)
+    return app

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,0 +1,3 @@
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()

--- a/backend/models/grn.py
+++ b/backend/models/grn.py
@@ -1,0 +1,7 @@
+from . import db
+
+class GRN(db.Model):
+    __tablename__ = 'grns'
+    id = db.Column(db.Integer, primary_key=True)
+    batch = db.Column(db.String(100), nullable=False)
+    quantity = db.Column(db.Integer, nullable=False)

--- a/backend/models/order.py
+++ b/backend/models/order.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from . import db
+
+class Order(db.Model):
+    __tablename__ = 'orders'
+    id = db.Column(db.Integer, primary_key=True)
+    product_id = db.Column(db.Integer, db.ForeignKey('products.id'), nullable=False)
+    quantity = db.Column(db.Integer, nullable=False)
+    status = db.Column(db.String(50), default='requested')
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    product = db.relationship('Product')

--- a/backend/models/product.py
+++ b/backend/models/product.py
@@ -1,0 +1,8 @@
+from . import db
+
+class Product(db.Model):
+    __tablename__ = 'products'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False)
+    quantity = db.Column(db.Integer, default=0)
+    warehouse = db.Column(db.String(100), nullable=True)

--- a/backend/models/stock_request.py
+++ b/backend/models/stock_request.py
@@ -1,0 +1,8 @@
+from . import db
+
+class StockRequest(db.Model):
+    __tablename__ = 'stock_requests'
+    id = db.Column(db.Integer, primary_key=True)
+    product = db.Column(db.String(100), nullable=False)
+    quantity = db.Column(db.Integer, nullable=False)
+    status = db.Column(db.String(50), default='pending')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,1 +1,3 @@
 flask
+flask_sqlalchemy
+flask_cors

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -1,0 +1,53 @@
+from flask import Blueprint, request, jsonify
+import uuid
+
+auth_bp = Blueprint('auth', __name__)
+
+USERS = {
+    'admin': {'password': 'adminpass', 'role': 'manufacturer'},
+    'cfauser': {'password': 'cfapass', 'role': 'cfa'},
+    'stockist': {'password': 'stockpass', 'role': 'super_stockist'},
+}
+
+TOKENS = {}
+
+@auth_bp.route('/login', methods=['POST'])
+def login():
+    data = request.get_json() or {}
+    username = data.get('username')
+    password = data.get('password')
+    user = USERS.get(username)
+    if not user or user['password'] != password:
+        return jsonify({'error': 'Invalid credentials'}), 401
+    token = str(uuid.uuid4())
+    TOKENS[token] = username
+    return jsonify({'token': token, 'role': user['role']})
+
+
+def get_user_from_token(token):
+    username = TOKENS.get(token)
+    if not username:
+        return None
+    user = USERS.get(username)
+    if not user:
+        return None
+    return {'username': username, 'role': user['role']}
+
+
+def role_required(role):
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            auth_header = request.headers.get('Authorization')
+            if not auth_header or not auth_header.startswith('Bearer '):
+                return jsonify({'error': 'Missing token'}), 401
+            token = auth_header.split(' ')[1]
+            user = get_user_from_token(token)
+            if not user:
+                return jsonify({'error': 'Invalid token'}), 401
+            if user['role'] != role:
+                return jsonify({'error': 'Forbidden'}), 403
+            request.user = user
+            return func(*args, **kwargs)
+        wrapper.__name__ = func.__name__
+        return wrapper
+    return decorator

--- a/backend/routes/cfa.py
+++ b/backend/routes/cfa.py
@@ -1,0 +1,31 @@
+from flask import Blueprint, request, jsonify
+from .auth import role_required
+from ..models import db
+from ..models.grn import GRN
+
+cfa_bp = Blueprint('cfa', __name__)
+
+@cfa_bp.route('/grn', methods=['GET', 'POST'])
+@role_required('cfa')
+def grn():
+    if request.method == 'POST':
+        data = request.get_json() or {}
+        batch = data.get('batch')
+        quantity = data.get('quantity')
+        if not batch or not quantity:
+            return jsonify({'error': 'Invalid GRN data'}), 400
+        record = GRN(batch=batch, quantity=quantity)
+        db.session.add(record)
+        db.session.commit()
+        return jsonify({'id': record.id, 'batch': record.batch}), 201
+    grns = GRN.query.all()
+    return jsonify([{'id': g.id, 'batch': g.batch, 'quantity': g.quantity} for g in grns])
+
+@cfa_bp.route('/tasks', methods=['GET'])
+@role_required('cfa')
+def tasks():
+    return jsonify({
+        'to_pack': 5,
+        'dispatch': 3,
+        'pending': 2
+    })

--- a/backend/routes/manufacturer.py
+++ b/backend/routes/manufacturer.py
@@ -1,0 +1,54 @@
+from flask import Blueprint, request, jsonify
+from .auth import role_required
+from ..models import db
+from ..models.product import Product
+from ..models.order import Order
+from ..models.grn import GRN
+
+manufacturer_bp = Blueprint('manufacturer', __name__)
+
+@manufacturer_bp.route('/products', methods=['GET', 'POST'])
+@role_required('manufacturer')
+def products():
+    if request.method == 'POST':
+        data = request.get_json() or {}
+        name = data.get('name')
+        quantity = data.get('quantity', 0)
+        warehouse = data.get('warehouse')
+        if not name:
+            return jsonify({'error': 'Invalid product data'}), 400
+        product = Product(name=name, quantity=quantity, warehouse=warehouse)
+        db.session.add(product)
+        db.session.commit()
+        return jsonify({'id': product.id, 'name': product.name}), 201
+    products = Product.query.all()
+    return jsonify([{'id': p.id, 'name': p.name, 'quantity': p.quantity} for p in products])
+
+@manufacturer_bp.route('/analytics/orders', methods=['GET'])
+@role_required('manufacturer')
+def order_analytics():
+    # Return dummy analytics data
+    return jsonify({
+        'daily': 120,
+        'weekly': 840,
+        'monthly': 3200
+    })
+
+@manufacturer_bp.route('/recall', methods=['POST'])
+@role_required('manufacturer')
+def recall():
+    data = request.get_json() or {}
+    batch = data.get('batch')
+    reason = data.get('reason')
+    if not batch or not reason:
+        return jsonify({'error': 'Invalid recall data'}), 400
+    # In a real app we would notify stockists here
+    return jsonify({'status': 'initiated', 'batch': batch})
+
+@manufacturer_bp.route('/schemes', methods=['GET'])
+@role_required('manufacturer')
+def schemes():
+    return jsonify([
+        {'id': 1, 'name': 'Buy One Get One'},
+        {'id': 2, 'name': 'Summer Discount'}
+    ])

--- a/backend/routes/super_stockist.py
+++ b/backend/routes/super_stockist.py
@@ -1,0 +1,22 @@
+from flask import Blueprint, request, jsonify
+from .auth import role_required
+from ..models import db
+from ..models.stock_request import StockRequest
+
+super_stockist_bp = Blueprint('super_stockist', __name__)
+
+@super_stockist_bp.route('/requests', methods=['GET', 'POST'])
+@role_required('super_stockist')
+def requests_endpoint():
+    if request.method == 'POST':
+        data = request.get_json() or {}
+        product = data.get('product')
+        qty = data.get('quantity')
+        if not product or not qty:
+            return jsonify({'error': 'Invalid request data'}), 400
+        req = StockRequest(product=product, quantity=qty)
+        db.session.add(req)
+        db.session.commit()
+        return jsonify({'id': req.id, 'product': req.product}), 201
+    reqs = StockRequest.query.all()
+    return jsonify([{'id': r.id, 'product': r.product, 'quantity': r.quantity} for r in reqs])

--- a/frontend/cfa.html
+++ b/frontend/cfa.html
@@ -316,6 +316,7 @@
     <div class="dashboard-container">
         <div class="header">
             <h1>CFA Dashboard</h1>
+            <p id="dailySummary" style="margin:0;font-size:0.9rem;"></p>
             <div class="notification-bell">
                 <span class="bell-icon">🔔</span>
                 <span class="notification-badge">3</span>
@@ -555,6 +556,17 @@
                     event.target.classList.add('active');
                     document.getElementById(targetTab).classList.add('active');
                 });
+            });
+
+            // fetch tasks summary
+            const token = localStorage.getItem('token');
+            fetch('/api/cfa/tasks', {
+                headers: { 'Authorization': `Bearer ${token}` }
+            }).then(r => r.json()).then(data => {
+                const summary = document.querySelector('#dailySummary');
+                if (summary) {
+                    summary.textContent = `To pack: ${data.to_pack}, Dispatch: ${data.dispatch}, Pending: ${data.pending}`;
+                }
             });
         });
     </script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -27,7 +27,7 @@
         e.preventDefault();
         const username = document.getElementById('username').value;
         const password = document.getElementById('password').value;
-        const resp = await fetch('/login', {
+        const resp = await fetch('/api/auth/login', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({username, password})
@@ -35,16 +35,16 @@
         const data = await resp.json();
         const result = document.getElementById('result');
         if (resp.ok) {
- f2igg8-codex/modify-get_user_from_token-to-return-username-and-role
             localStorage.setItem('token', data.token);
             localStorage.setItem('role', data.role);
-            window.location.href = '/dashboard';
-
-
-            result.textContent = `Logged in as ${data.role}. Token: ${data.token}`;
- main
- main
- main
+            if (data.role === 'manufacturer') {
+                window.location.href = '/manufacterer.html';
+            } else if (data.role === 'cfa') {
+                window.location.href = '/cfa.html';
+            } else {
+                window.location.href = '/stockist.html';
+            }
+            result.textContent = `Logged in as ${data.role}`;
         } else {
             result.textContent = data.error || 'Login failed';
         }

--- a/frontend/manufacterer.html
+++ b/frontend/manufacterer.html
@@ -1603,20 +1603,51 @@
         }
         renderCharts();
 
-        // Placeholder for form submissions - to be replaced with actual API calls
+        const token = localStorage.getItem('token');
         const forms = document.querySelectorAll('form');
-        forms.forEach(form => {
-            form.addEventListener('submit', function(e) {
+
+        document.getElementById('productForm').addEventListener('submit', async function(e) {
+            e.preventDefault();
+            const payload = {
+                name: document.getElementById('productName').value,
+                quantity: 0,
+                warehouse: 'Main'
+            };
+            const resp = await fetch('/api/manufacturer/products', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${token}`
+                },
+                body: JSON.stringify(payload)
+            });
+            if (resp.ok) {
+                alert('Product added');
+            }
+            closeModal('addProductModal');
+        });
+
+        const recallForm = document.getElementById('recallForm');
+        if (recallForm) {
+            recallForm.addEventListener('submit', async function(e) {
                 e.preventDefault();
-                console.log(`Form ${this.id} submitted. Data would be sent to backend.`);
-                alert('Form submitted (dev placeholder). Check console.');
-                // Example: const formData = new FormData(this); apiService.submit(this.id, formData);
-                const parentModal = this.closest('.modal');
-                if (parentModal) {
-                    closeModal(parentModal.id);
+                const payload = {
+                    batch: document.getElementById('recallBatchNo').value,
+                    reason: document.getElementById('recallReason').value
+                };
+                const resp = await fetch('/api/manufacturer/recall', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': `Bearer ${token}`
+                    },
+                    body: JSON.stringify(payload)
+                });
+                if (resp.ok) {
+                    alert('Recall initiated');
                 }
             });
-        });
+        }
 
     </script>
 </body>

--- a/main.py
+++ b/main.py
@@ -1,0 +1,10 @@
+from backend.app import create_app
+from backend.models import db
+
+app = create_app()
+
+with app.app_context():
+    db.create_all()
+
+if __name__ == '__main__':
+    app.run(debug=True, port=8000)


### PR DESCRIPTION
## Summary
- add Flask SQLAlchemy models for products, orders, GRNs and stock requests
- implement auth, manufacturer, CFA and super stockist routes under `/api/*`
- create `main.py` and update app factory
- connect manufacturer dashboard forms to API
- show CFA daily task summary from backend
- update login logic to route users by role

## Testing
- `pip install -r backend/requirements.txt`
- `python main.py` *(fails: Stopped due to tty output)*
- `pytest tests/` *(fails: directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856082ab8d0832ab8a460a197e0c78b