### PR TITLE
[Backend] Add order API

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -5,8 +5,10 @@ from backend.auth import auth_bp
 from backend.routes.manufacturer import manufacturer_bp
 from backend.routes.cfa import cfa_bp
 from backend.routes.super_stockist import super_stockist_bp
+from backend.routes.order import order_bp
 from backend.database import engine
 from backend.models import Base
+from backend.models.order import Order  # ensure table registration
 
 app = Flask(__name__, static_folder='../frontend', static_url_path='')
 
@@ -18,6 +20,7 @@ app.register_blueprint(auth_bp, url_prefix='/api/auth')
 app.register_blueprint(manufacturer_bp, url_prefix='/api/manufacturer')
 app.register_blueprint(cfa_bp, url_prefix='/api/cfa')
 app.register_blueprint(super_stockist_bp, url_prefix='/api/super_stockist')
+app.register_blueprint(order_bp, url_prefix='/api')
 
 @app.route('/')
 def index():

--- a/backend/models/order.py
+++ b/backend/models/order.py
@@ -1,0 +1,9 @@
+from sqlalchemy import Column, Integer, String
+from . import Base
+
+class Order(Base):
+    __tablename__ = 'orders'
+    id = Column(Integer, primary_key=True)
+    product = Column(String, nullable=False)
+    quantity = Column(Integer, nullable=False)
+    status = Column(String, nullable=False, default='requested')

--- a/backend/routes/order.py
+++ b/backend/routes/order.py
@@ -1,0 +1,29 @@
+from flask import Blueprint, request, jsonify
+from sqlalchemy.orm import Session
+from backend.auth import role_required
+from backend.database import SessionLocal
+from backend.models.order import Order
+
+order_bp = Blueprint('order', __name__)
+
+@order_bp.route('/orders', methods=['GET', 'POST'])
+@role_required('super_stockist')
+def orders():
+    session: Session = SessionLocal()
+    if request.method == 'POST':
+        data = request.json or {}
+        product = data.get('product')
+        quantity = data.get('quantity')
+        if not product or quantity is None:
+            session.close()
+            return jsonify({'error': 'Invalid order data'}), 400
+        order = Order(product=product, quantity=quantity, status='requested')
+        session.add(order)
+        session.commit()
+        result = {'id': order.id, 'product': order.product, 'quantity': order.quantity, 'status': order.status}
+        session.close()
+        return jsonify(result), 201
+    orders = session.query(Order).all()
+    result = [{'id': o.id, 'product': o.product, 'quantity': o.quantity, 'status': o.status} for o in orders]
+    session.close()
+    return jsonify(result)


### PR DESCRIPTION
## Summary
- add `Order` model for stockist orders
- expose `/api/orders` endpoints via new blueprint
- register order routes in the Flask app

## Testing
- `pip install -r backend/requirements.txt`
- `python -m backend.app` *(startup verified)*
- `curl -s -X POST http://localhost:8000/api/auth/login -H 'Content-Type: application/json' -d '{"username": "stockist", "password": "stockpass"}'`
- `curl -s -X POST http://localhost:8000/api/orders -H 'Content-Type: application/json' -H 'Authorization: Bearer <TOKEN>' -d '{"product": "TestProd", "quantity": 5}'`
- `curl -s http://localhost:8000/api/orders -H 'Authorization: Bearer <TOKEN>'`
- `pytest tests/` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_685622576fec832a96b571719239dac0