### PR TITLE
[Backend] Implement order workflow UI

### DIFF
--- a/backend/routes/order.py
+++ b/backend/routes/order.py
@@ -1,16 +1,19 @@
 from flask import Blueprint, request, jsonify
 from sqlalchemy.orm import Session
-from backend.auth import role_required
+from backend.auth import role_required, roles_required
 from backend.database import SessionLocal
 from backend.models.order import Order
 
 order_bp = Blueprint('order', __name__)
 
 @order_bp.route('/orders', methods=['GET', 'POST'])
-@role_required('super_stockist')
+@roles_required('super_stockist', 'manufacturer', 'cfa')
 def orders():
     session: Session = SessionLocal()
     if request.method == 'POST':
+        if request.user['role'] != 'super_stockist':
+            session.close()
+            return jsonify({'error': 'Forbidden'}), 403
         data = request.json or {}
         product = data.get('product')
         quantity = data.get('quantity')
@@ -23,7 +26,83 @@ def orders():
         result = {'id': order.id, 'product': order.product, 'quantity': order.quantity, 'status': order.status}
         session.close()
         return jsonify(result), 201
-    orders = session.query(Order).all()
+    status = request.args.get('status')
+    query = session.query(Order)
+    if status:
+        query = query.filter(Order.status == status)
+    orders = query.all()
     result = [{'id': o.id, 'product': o.product, 'quantity': o.quantity, 'status': o.status} for o in orders]
+    session.close()
+    return jsonify(result)
+
+
+@order_bp.route('/orders/<int:order_id>/approve', methods=['POST'])
+@role_required('manufacturer')
+def approve_order(order_id):
+    """Manufacturer approves an order."""
+    session: Session = SessionLocal()
+    order = session.query(Order).get(order_id)
+    if not order:
+        session.close()
+        return jsonify({'error': 'Order not found'}), 404
+    if order.status != 'requested':
+        session.close()
+        return jsonify({'error': 'Order cannot be approved'}), 400
+    order.status = 'approved'
+    session.commit()
+    result = {
+        'id': order.id,
+        'product': order.product,
+        'quantity': order.quantity,
+        'status': order.status
+    }
+    session.close()
+    return jsonify(result)
+
+
+@order_bp.route('/orders/<int:order_id>/dispatch', methods=['POST'])
+@role_required('cfa')
+def dispatch_order(order_id):
+    """CFA dispatches an approved order."""
+    session: Session = SessionLocal()
+    order = session.query(Order).get(order_id)
+    if not order:
+        session.close()
+        return jsonify({'error': 'Order not found'}), 404
+    if order.status != 'approved':
+        session.close()
+        return jsonify({'error': 'Order cannot be dispatched'}), 400
+    order.status = 'in_transit'
+    session.commit()
+    result = {
+        'id': order.id,
+        'product': order.product,
+        'quantity': order.quantity,
+        'status': order.status
+    }
+    session.close()
+    return jsonify(result)
+
+
+@order_bp.route('/orders/<int:order_id>/deliver', methods=['POST'])
+@role_required('super_stockist')
+def deliver_order(order_id):
+    """Stockist confirms delivery of an order."""
+    session: Session = SessionLocal()
+    order = session.query(Order).get(order_id)
+    if not order:
+        session.close()
+        return jsonify({'error': 'Order not found'}), 404
+    if order.status != 'in_transit':
+        session.close()
+        return jsonify({'error': 'Order cannot be marked delivered'}), 400
+    order.status = 'delivered'
+    session.commit()
+    result = {
+        'id': order.id,
+        'product': order.product,
+        'quantity': order.quantity,
+        'status': order.status
+    }
     session.close()
     return jsonify(result)

--- a/frontend/cfa.html
+++ b/frontend/cfa.html
@@ -352,34 +352,7 @@
 
                 <div class="list-section">
                     <h3>Dispatch Queue (Approved Orders)</h3>
-                    <div class="list-item">
-                        <div>
-                            <strong>#ORD1001</strong> - Customer A
-                            <p>5 items | <span class="status-chip approved">Approved</span></p>
-                        </div>
-                        <button>Start Packing</button>
-                    </div>
-                    <div class="list-item">
-                        <div>
-                            <strong>#ORD1002</strong> - Customer B
-                            <p>12 items | <span class="status-chip packed">Packed</span></p>
-                        </div>
-                        <button>Generate Slip</button>
-                    </div>
-                    <div class="list-item">
-                        <div>
-                            <strong>#ORD1003</strong> - Customer C
-                            <p>3 items | <span class="status-chip approved">Approved</span></p>
-                        </div>
-                        <button>Start Packing</button>
-                    </div>
-                    <div class="list-item">
-                        <div>
-                            <strong>#ORD1004</strong> - Customer D
-                            <p>8 items | <span class="status-chip packed">Packed</span></p>
-                        </div>
-                        <button>Mark Shipped</button>
-                    </div>
+                    <div id="dispatchList"></div>
                 </div>
 
                 <div class="list-section">
@@ -577,6 +550,26 @@
                 });
             }
 
+            async function loadDispatchQueue() {
+                const resp = await fetch('/api/orders?status=approved', { headers: { 'Authorization': `Bearer ${token}` } });
+                const data = await resp.json();
+                const list = document.getElementById('dispatchList');
+                list.innerHTML = '';
+                data.forEach(o => {
+                    const div = document.createElement('div');
+                    div.className = 'list-item';
+                    div.innerHTML = `<div><strong>#${o.id}</strong> - ${o.product}<p>${o.quantity} units | <span class="status-chip approved">Approved</span></p></div>`;
+                    const btn = document.createElement('button');
+                    btn.textContent = 'Dispatch';
+                    btn.addEventListener('click', async () => {
+                        await fetch(`/api/orders/${o.id}/dispatch`, { method: 'POST', headers: { 'Authorization': `Bearer ${token}` } });
+                        await loadDispatchQueue();
+                    });
+                    div.appendChild(btn);
+                    list.appendChild(div);
+                });
+            }
+
             document.getElementById('grnForm').addEventListener('submit', async e => {
                 e.preventDefault();
                 const payload = { batch: document.getElementById('grnBatch').value, quantity: document.getElementById('grnQty').value };
@@ -593,6 +586,7 @@
             });
 
             loadGrns();
+            loadDispatchQueue();
         });
     </script>
 </body>

--- a/frontend/manufacterer.html
+++ b/frontend/manufacterer.html
@@ -771,6 +771,7 @@
                 <li><a href="#pack-configs" class="nav-link" data-section="pack-configs-section"><i class="fas fa-box-open"></i> Pack Configs</a></li>
                 <li><a href="#pricing-catalogs" class="nav-link" data-section="pricing-catalogs-section"><i class="fas fa-tags"></i> Pricing Catalogs</a></li>
                 <li><a href="#cfa-management" class="nav-link" data-section="cfa-management-section"><i class="fas fa-warehouse"></i> CFA Management</a></li>
+                <li><a href="#order-approval" class="nav-link" data-section="order-approval-section"><i class="fas fa-clipboard-check"></i> Orders</a></li>
                 <li><a href="#stock-visibility" class="nav-link" data-section="stock-visibility-section"><i class="fas fa-eye"></i> Stock Visibility</a></li>
                 <li><a href="#audit-trail" class="nav-link" data-section="audit-trail-section"><i class="fas fa-clipboard-list"></i> Audit & Compliance</a></li>
                 <li><a href="#recall-trigger" class="nav-link" data-section="recall-trigger-section"><i class="fas fa-exclamation-triangle"></i> Recall Trigger</a></li>
@@ -1056,6 +1057,15 @@
                             </tbody>
                         </table>
                     </div>
+                </div>
+            </section>
+
+            <section id="order-approval-section" class="content-section">
+                <div class="card">
+                    <div class="card-header">
+                        <h3>Pending Orders</h3>
+                    </div>
+                    <div id="orderList"></div>
                 </div>
             </section>
 
@@ -1429,6 +1439,10 @@
             <i class="fas fa-box-open"></i>
             <span>Products</span>
         </a>
+        <a href="#order-approval" class="bottom-nav-item" data-section="order-approval-section">
+            <i class="fas fa-clipboard-check"></i>
+            <span>Orders</span>
+        </a>
         <a href="#user-access" class="bottom-nav-item" data-section="user-access-section">
             <i class="fas fa-users-cog"></i>
             <span>Users</span>
@@ -1623,7 +1637,28 @@
             }
         });
 
+        async function loadOrders() {
+            const resp = await fetch('/api/orders?status=requested', { headers: { 'Authorization': `Bearer ${token}` } });
+            const data = await resp.json();
+            const list = document.getElementById('orderList');
+            list.innerHTML = '';
+            data.forEach(o => {
+                const div = document.createElement('div');
+                div.className = 'list-item';
+                div.innerHTML = `<div><strong>#${o.id}</strong> - ${o.product}<p>${o.quantity} units | <span class="status-chip">Requested</span></p></div>`;
+                const btn = document.createElement('button');
+                btn.textContent = 'Approve';
+                btn.addEventListener('click', async () => {
+                    await fetch(`/api/orders/${o.id}/approve`, { method: 'POST', headers: { 'Authorization': `Bearer ${token}` } });
+                    await loadOrders();
+                });
+                div.appendChild(btn);
+                list.appendChild(div);
+            });
+        }
+
         loadProducts();
+        loadOrders();
 
     </script>
 </body>

--- a/frontend/stockist.html
+++ b/frontend/stockist.html
@@ -534,6 +534,11 @@
                 </div>
 
                 <div class="list-section">
+                    <h3>Incoming Orders</h3>
+                    <div id="incomingList"></div>
+                </div>
+
+                <div class="list-section">
                     <h3>Order Status Timeline (Last Order: #ORD1234)</h3>
                     <div class="timeline-container">
                         <div class="timeline-step active">
@@ -769,7 +774,7 @@
                 btn.addEventListener('click', async () => {
                     const product = btn.dataset.product;
                     const payload = { product, quantity: 1 };
-                    await fetch('/api/super_stockist/requests', {
+                    await fetch('/api/orders', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
                         body: JSON.stringify(payload)
@@ -777,6 +782,28 @@
                     alert(`${product} added to cart`);
                 });
             });
+
+            async function loadIncomingOrders() {
+                const resp = await fetch('/api/orders?status=in_transit', { headers: { 'Authorization': `Bearer ${token}` } });
+                const data = await resp.json();
+                const list = document.getElementById('incomingList');
+                list.innerHTML = '';
+                data.forEach(o => {
+                    const div = document.createElement('div');
+                    div.className = 'list-item';
+                    div.innerHTML = `<div><strong>#${o.id}</strong> - ${o.product}<p>${o.quantity} units in transit</p></div>`;
+                    const btn = document.createElement('button');
+                    btn.textContent = 'Mark Delivered';
+                    btn.addEventListener('click', async () => {
+                        await fetch(`/api/orders/${o.id}/deliver`, { method: 'POST', headers: { 'Authorization': `Bearer ${token}` } });
+                        await loadIncomingOrders();
+                    });
+                    div.appendChild(btn);
+                    list.appendChild(div);
+                });
+            }
+
+            loadIncomingOrders();
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- allow multiple roles with `roles_required` decorator
- enable filtering and creation in `/api/orders`
- display manufacturer approval queue
- display CFA dispatch queue
- show stockist incoming orders

## Testing
- `pytest tests/` *(fails: file or directory not found)*
- `python -m backend.app` *(works: server starts)*

------
https://chatgpt.com/codex/tasks/task_e_6856276eae5c832aaee269ba978227db