### PR TITLE
[Backend] Add user management for manufacturer

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -11,6 +11,7 @@ from backend.models import Base
 from backend.models.order import Order  # ensure table registration
 from backend.models.batch import Batch
 from backend.models.pack_config import PackConfig
+from backend.models.user import User
 
 app = Flask(__name__, static_folder='../frontend', static_url_path='')
 

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, Integer, String
+from . import Base
+
+class User(Base):
+    __tablename__ = 'users'
+    id = Column(Integer, primary_key=True)
+    username = Column(String, unique=True, nullable=False)
+    password = Column(String, nullable=False)
+    role = Column(String, nullable=False)
+

--- a/frontend/manufacterer.html
+++ b/frontend/manufacterer.html
@@ -1287,30 +1287,6 @@
                                 </tr>
                             </thead>
                             <tbody id="userAccessTableBody">
-                                <tr>
-                                    <td>USR001</td>
-                                    <td>cfa_manager_mum</td>
-                                    <td>Ramesh Patel</td>
-                                    <td>CFA</td>
-                                    <td>Active</td>
-                                    <td>Device ID: XYZ123</td>
-                                    <td class="action-buttons">
-                                        <button class="btn btn-secondary btn-sm"><i class="fas fa-edit"></i> Edit</button>
-                                        <button class="btn btn-danger btn-sm"><i class="fas fa-user-slash"></i> Deactivate</button>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td>USR002</td>
-                                    <td>qc_inspector</td>
-                                    <td>Priya Sharma</td>
-                                    <td>Quality Control</td>
-                                    <td>Active</td>
-                                    <td>IP Whitelist: 192.168.1.0/24</td>
-                                    <td class="action-buttons">
-                                        <button class="btn btn-secondary btn-sm"><i class="fas fa-edit"></i> Edit</button>
-                                        <button class="btn btn-danger btn-sm"><i class="fas fa-user-slash"></i> Deactivate</button>
-                                    </td>
-                                </tr>
                             </tbody>
                         </table>
                     </div>
@@ -1531,9 +1507,28 @@
     </div>
     <div id="addUserModal" class="modal">
         <div class="modal-content">
-            <div class="modal-header"><h3>Create New User</h3><span class="close-btn" onclick="closeModal('addUserModal')">&times;</span></div>
-            <p>Form for creating new user goes here...</p>
-            <div class="modal-footer"><button type="button" class="btn btn-secondary" onclick="closeModal('addUserModal')">Cancel</button><button type="submit" class="btn btn-success">Create User</button></div>
+            <form id="userForm">
+                <div class="modal-header"><h3>Create New User</h3><span class="close-btn" onclick="closeModal('addUserModal')">&times;</span></div>
+                <div class="form-group">
+                    <label for="newUsername">Username:</label>
+                    <input type="text" id="newUsername" required>
+                </div>
+                <div class="form-group">
+                    <label for="newPassword">Password:</label>
+                    <input type="password" id="newPassword" required>
+                </div>
+                <div class="form-group">
+                    <label for="newRole">Role:</label>
+                    <select id="newRole" required>
+                        <option value="cfa">CFA</option>
+                        <option value="super_stockist">Stockist</option>
+                    </select>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" onclick="closeModal('addUserModal')">Cancel</button>
+                    <button type="submit" class="btn btn-success">Create User</button>
+                </div>
+            </form>
         </div>
     </div>
 
@@ -1919,6 +1914,45 @@
         loadBatches();
         loadPackConfigs();
         loadOrders();
+        loadUsers();
+
+        document.getElementById('userForm').addEventListener('submit', async function(e) {
+            e.preventDefault();
+            const payload = {
+                username: document.getElementById('newUsername').value,
+                password: document.getElementById('newPassword').value,
+                role: document.getElementById('newRole').value
+            };
+            const resp = await fetch('/api/manufacturer/users', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+                body: JSON.stringify(payload)
+            });
+            if (resp.ok) {
+                document.getElementById('userForm').reset();
+                closeModal('addUserModal');
+                await loadUsers();
+            }
+        });
+
+        async function loadUsers() {
+            const resp = await fetch('/api/manufacturer/users', { headers: { 'Authorization': `Bearer ${token}` } });
+            const data = await resp.json();
+            const body = document.getElementById('userAccessTableBody');
+            body.innerHTML = '';
+            data.forEach(u => {
+                const row = document.createElement('tr');
+                row.innerHTML = `
+                    <td>${u.id}</td>
+                    <td>${u.username}</td>
+                    <td></td>
+                    <td>${u.role}</td>
+                    <td>Active</td>
+                    <td></td>
+                    <td></td>`;
+                body.appendChild(row);
+            });
+        }
 
     </script>
 </body>


### PR DESCRIPTION
## Summary
- create User model for DB-backed accounts
- allow manufacturer API to create/list CFA and stockist users
- persist user accounts during login in auth layer
- import User table in app init
- add user management UI and JS in manufacturer dashboard

## Testing
- `python -m pip install -r backend/requirements.txt`
- `python -m backend.app` *(fails: running in bg)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685635e89238832a86ac30846b4de4db