### PR TITLE
[Frontend] Enable CRUD for manufacturer modules

### DIFF
--- a/frontend/manufacterer.html
+++ b/frontend/manufacterer.html
@@ -1376,8 +1376,8 @@
             <div class="modal-header"><h3>Add New Batch</h3><span class="close-btn" onclick="closeModal('addBatchModal')">&times;</span></div>
             <form id="batchForm">
                 <div class="form-group">
-                    <label for="batchProductId">Product ID:</label>
-                    <input type="number" id="batchProductId" required>
+                    <label for="batchProductId">Product:</label>
+                    <select id="batchProductId" required></select>
                 </div>
                 <div class="form-group">
                     <label for="batchNo">Batch No:</label>
@@ -1413,8 +1413,8 @@
             <form id="editBatchForm">
                 <input type="hidden" id="editBatchId">
                 <div class="form-group">
-                    <label for="editBatchProductId">Product ID:</label>
-                    <input type="number" id="editBatchProductId" required>
+                    <label for="editBatchProductId">Product:</label>
+                    <select id="editBatchProductId" required></select>
                 </div>
                 <div class="form-group">
                     <label for="editBatchNo">Batch No:</label>
@@ -1449,8 +1449,8 @@
             <div class="modal-header"><h3>Add New Pack Config</h3><span class="close-btn" onclick="closeModal('addPackConfigModal')">&times;</span></div>
             <form id="packConfigForm">
                 <div class="form-group">
-                    <label for="packProductId">Product ID:</label>
-                    <input type="number" id="packProductId" required>
+                    <label for="packProductId">Product:</label>
+                    <select id="packProductId" required></select>
                 </div>
                 <div class="form-group">
                     <label for="packType">Pack Type:</label>
@@ -1478,8 +1478,8 @@
             <form id="editPackConfigForm">
                 <input type="hidden" id="editPackConfigId">
                 <div class="form-group">
-                    <label for="editPackProductId">Product ID:</label>
-                    <input type="number" id="editPackProductId" required>
+                    <label for="editPackProductId">Product:</label>
+                    <select id="editPackProductId" required></select>
                 </div>
                 <div class="form-group">
                     <label for="editPackType">Pack Type:</label>
@@ -1753,7 +1753,42 @@
                     <td>${p.composition || ''}</td>
                     <td>${p.category || ''}</td>
                     <td class="action-buttons"></td>`;
+                const actionTd = row.querySelector('.action-buttons');
+                const editBtn = document.createElement('button');
+                editBtn.className = 'btn btn-secondary btn-sm';
+                editBtn.innerHTML = '<i class="fas fa-edit"></i> Edit';
+                editBtn.addEventListener('click', () => openModal('editProductModal', p));
+                const delBtn = document.createElement('button');
+                delBtn.className = 'btn btn-danger btn-sm';
+                delBtn.innerHTML = '<i class="fas fa-trash-alt"></i> Delete';
+                delBtn.addEventListener('click', async () => {
+                    if (confirm('Delete product?')) {
+                        await fetch(`/api/manufacturer/products/${p.id}`, { method: 'DELETE', headers: { 'Authorization': `Bearer ${token}` } });
+                        await loadProducts();
+                        await loadBatches();
+                        await loadPackConfigs();
+                    }
+                });
+                actionTd.appendChild(editBtn);
+                actionTd.appendChild(delBtn);
                 body.appendChild(row);
+            });
+            populateProductDropdowns(data);
+        }
+
+        function populateProductDropdowns(products) {
+            const selects = ['batchProductId','editBatchProductId','packProductId','editPackProductId'];
+            selects.forEach(id => {
+                const sel = document.getElementById(id);
+                if (sel) {
+                    sel.innerHTML = '';
+                    products.forEach(p => {
+                        const opt = document.createElement('option');
+                        opt.value = p.id;
+                        opt.textContent = p.name;
+                        sel.appendChild(opt);
+                    });
+                }
             });
         }
 
@@ -1774,6 +1809,25 @@
             });
             if (resp.ok) {
                 closeModal('addProductModal');
+                await loadProducts();
+            }
+        });
+
+        document.getElementById('editProductForm').addEventListener('submit', async function(e) {
+            e.preventDefault();
+            const id = document.getElementById('editProductId').value;
+            const payload = {
+                name: document.getElementById('editProductName').value,
+                description: document.getElementById('editProductDescription').value,
+                hsn: document.getElementById('editProductHSN').value
+            };
+            const resp = await fetch(`/api/manufacturer/products/${id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+                body: JSON.stringify(payload)
+            });
+            if (resp.ok) {
+                closeModal('editProductModal');
                 await loadProducts();
             }
         });
@@ -1876,11 +1930,21 @@
                     <td>${b.quantity || ''}</td>
                     <td class="action-buttons"></td>`;
                 const actionTd = row.querySelector('.action-buttons');
-                const btn = document.createElement('button');
-                btn.className = 'btn btn-secondary btn-sm';
-                btn.innerHTML = '<i class="fas fa-edit"></i> Edit';
-                btn.addEventListener('click', () => openModal('editBatchModal', b));
-                actionTd.appendChild(btn);
+                const editBtn = document.createElement('button');
+                editBtn.className = 'btn btn-secondary btn-sm';
+                editBtn.innerHTML = '<i class="fas fa-edit"></i> Edit';
+                editBtn.addEventListener('click', () => openModal('editBatchModal', b));
+                const delBtn = document.createElement('button');
+                delBtn.className = 'btn btn-danger btn-sm';
+                delBtn.innerHTML = '<i class="fas fa-trash-alt"></i> Delete';
+                delBtn.addEventListener('click', async () => {
+                    if (confirm('Delete batch?')) {
+                        await fetch(`/api/manufacturer/batches/${b.id}`, { method: 'DELETE', headers: { 'Authorization': `Bearer ${token}` } });
+                        await loadBatches();
+                    }
+                });
+                actionTd.appendChild(editBtn);
+                actionTd.appendChild(delBtn);
                 body.appendChild(row);
             });
         }
@@ -1900,11 +1964,21 @@
                     <td>${c.dimensions || ''}</td>
                     <td class="action-buttons"></td>`;
                 const actionTd = row.querySelector('.action-buttons');
-                const btn = document.createElement('button');
-                btn.className = 'btn btn-secondary btn-sm';
-                btn.innerHTML = '<i class="fas fa-edit"></i> Edit';
-                btn.addEventListener('click', () => openModal('editPackConfigModal', c));
-                actionTd.appendChild(btn);
+                const editBtn = document.createElement('button');
+                editBtn.className = 'btn btn-secondary btn-sm';
+                editBtn.innerHTML = '<i class="fas fa-edit"></i> Edit';
+                editBtn.addEventListener('click', () => openModal('editPackConfigModal', c));
+                const delBtn = document.createElement('button');
+                delBtn.className = 'btn btn-danger btn-sm';
+                delBtn.innerHTML = '<i class="fas fa-trash-alt"></i> Delete';
+                delBtn.addEventListener('click', async () => {
+                    if (confirm('Delete config?')) {
+                        await fetch(`/api/manufacturer/pack-configs/${c.id}`, { method: 'DELETE', headers: { 'Authorization': `Bearer ${token}` } });
+                        await loadPackConfigs();
+                    }
+                });
+                actionTd.appendChild(editBtn);
+                actionTd.appendChild(delBtn);
                 body.appendChild(row);
             });
         }


### PR DESCRIPTION
## Summary
- allow manufacturer to edit/delete products, batches and pack configs
- show product dropdowns when adding/editing batches and pack configs
- wire up product update API
- expose routes for product update/delete and for batch/pack config deletion

## Testing
- `python main.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68563e6b5000832a9d6193b61a264bb9