### PR TITLE
[Backend] add inventory model and endpoints

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -7,6 +7,7 @@ from backend.routes.cfa import cfa_bp
 from backend.routes.super_stockist import super_stockist_bp
 from backend.routes.order import order_bp
 from backend.routes.product import product_bp
+from backend.routes.inventory import inventory_bp
 from backend.database import engine, SessionLocal
 from backend.models import Base
 from backend.models.order import Order  # ensure table registration
@@ -14,6 +15,7 @@ from backend.models.batch import Batch
 from backend.models.pack_config import PackConfig
 from backend.models.product import Product
 from backend.models.user import User
+from backend.models.inventory import Inventory
 
 app = Flask(__name__, static_folder="../frontend", static_url_path="")
 
@@ -71,6 +73,7 @@ app.register_blueprint(cfa_bp, url_prefix="/api/cfa")
 app.register_blueprint(super_stockist_bp, url_prefix="/api/super_stockist")
 app.register_blueprint(order_bp, url_prefix="/api")
 app.register_blueprint(product_bp, url_prefix="/api")
+app.register_blueprint(inventory_bp, url_prefix="/api")
 
 
 @app.route("/")

--- a/backend/models/inventory.py
+++ b/backend/models/inventory.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, Integer, String, Date, ForeignKey
+from . import Base
+
+class Inventory(Base):
+    __tablename__ = 'inventory'
+    id = Column(Integer, primary_key=True)
+    location = Column(String, nullable=False)
+    product_id = Column(Integer, ForeignKey('products.id'), nullable=False)
+    batch_no = Column(String, nullable=False)
+    exp_date = Column(Date, nullable=True)
+    quantity = Column(Integer, nullable=False)

--- a/backend/routes/inventory.py
+++ b/backend/routes/inventory.py
@@ -1,0 +1,72 @@
+from datetime import date
+from flask import Blueprint, request, jsonify
+from sqlalchemy.orm import Session
+from backend.auth import role_required, roles_required
+from backend.database import SessionLocal
+from backend.models.inventory import Inventory
+from backend.models.product import Product
+
+
+def _parse_iso_date(value):
+    if isinstance(value, str) and value:
+        try:
+            return date.fromisoformat(value)
+        except ValueError:
+            return None
+    return value
+
+inventory_bp = Blueprint('inventory', __name__)
+
+
+@inventory_bp.route('/inventory', methods=['GET'])
+@role_required('manufacturer')
+def list_inventory():
+    session: Session = SessionLocal()
+    rows = session.query(Inventory, Product.name).join(Product, Inventory.product_id == Product.id).all()
+    result = []
+    for inv, name in rows:
+        result.append({
+            'id': inv.id,
+            'location': inv.location,
+            'product_id': inv.product_id,
+            'product_name': name,
+            'batch_no': inv.batch_no,
+            'exp_date': str(inv.exp_date) if inv.exp_date else None,
+            'quantity': inv.quantity
+        })
+    session.close()
+    return jsonify(result)
+
+
+@inventory_bp.route('/inventory', methods=['POST'])
+@roles_required('cfa', 'super_stockist')
+def add_inventory():
+    session: Session = SessionLocal()
+    data = request.json or {}
+    product_id = data.get('product_id')
+    batch_no = data.get('batch_no')
+    quantity = data.get('quantity')
+    if not product_id or not batch_no or quantity is None:
+        session.close()
+        return jsonify({'error': 'Invalid inventory data'}), 400
+    exp_date = _parse_iso_date(data.get('exp_date'))
+    location = data.get('location') or request.user['username']
+    inventory = Inventory(
+        location=location,
+        product_id=product_id,
+        batch_no=batch_no,
+        exp_date=exp_date,
+        quantity=quantity
+    )
+    session.add(inventory)
+    session.commit()
+    result = {
+        'id': inventory.id,
+        'location': inventory.location,
+        'product_id': inventory.product_id,
+        'batch_no': inventory.batch_no,
+        'exp_date': str(inventory.exp_date) if inventory.exp_date else None,
+        'quantity': inventory.quantity
+    }
+    session.close()
+    return jsonify(result), 201

--- a/frontend/manufacterer.html
+++ b/frontend/manufacterer.html
@@ -1105,36 +1105,7 @@
                                 </tr>
                             </thead>
                             <tbody id="liveStockTableBody">
-                                <tr>
-                                    <td>CFA01 - Mumbai</td>
-                                    <td>PROD001</td>
-                                    <td>Paracetamol 500mg</td>
-                                    <td>B001XYZ</td>
-                                    <td>5000</td>
-                                    <td>2026-01-14</td>
-                                    <td>150</td>
-                                    <td style="color:#28a745; font-weight: 500;">Healthy</td>
-                                </tr>
-                                 <tr>
-                                    <td>SS005 - Pune</td>
-                                    <td>PROD002</td>
-                                    <td>Amoxicillin 250mg</td>
-                                    <td>B003ABC</td>
-                                    <td>200</td>
-                                    <td>2025-07-30</td>
-                                    <td>90</td>
-                                    <td style="color:#ffc107; font-weight: 500;">Nearing Expiry</td>
-                                </tr>
-                                <tr>
-                                    <td>CFA02 - Delhi</td>
-                                    <td>PROD001</td>
-                                    <td>Paracetamol 500mg</td>
-                                    <td>B004DEF</td>
-                                    <td>15000</td>
-                                    <td>2026-02-28</td>
-                                    <td>120</td>
-                                    <td style="color:#fd7e14; font-weight: 500;">Overstocked</td>
-                                </tr>
+                                <!-- data populated by loadLiveStock() -->
                             </tbody>
                         </table>
                     </div>
@@ -2003,10 +1974,31 @@
             });
         }
 
+        async function loadLiveStock() {
+            const resp = await fetch('/api/inventory', { headers: { 'Authorization': `Bearer ${token}` } });
+            const data = await resp.json();
+            const body = document.getElementById('liveStockTableBody');
+            body.innerHTML = '';
+            data.forEach(item => {
+                const row = document.createElement('tr');
+                row.innerHTML = `
+                    <td>${item.location}</td>
+                    <td>${item.product_id}</td>
+                    <td>${item.product_name || ''}</td>
+                    <td>${item.batch_no}</td>
+                    <td>${item.quantity}</td>
+                    <td>${item.exp_date || ''}</td>
+                    <td></td>
+                    <td></td>`;
+                body.appendChild(row);
+            });
+        }
+
         loadProducts();
         loadBatches();
         loadPackConfigs();
         loadOrders();
+        loadLiveStock();
         loadUsers();
 
         document.getElementById('userForm').addEventListener('submit', async function(e) {


### PR DESCRIPTION
## Summary
- create inventory model and blueprint
- hook inventory routes in Flask app
- load live stock via API in manufacturer dashboard

## Testing
- `python main.py`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_685657b9770c832a842983ccd9da0e57