### PR TITLE
[Frontend] Display super stockist stock via API

### DIFF
--- a/frontend/stockist.html
+++ b/frontend/stockist.html
@@ -1220,7 +1220,7 @@
             fetchOrders();
             loadStockistBatches();
             loadStockistPricing();
-            loadStockistMyStock();
+            fetchMyStock();
             loadStockistAuditLogs();
         });
 
@@ -1279,6 +1279,13 @@
             const data = await resp.json();
             dummyStockistData.myOrders = data;
             loadMyOrders();
+        }
+
+        async function fetchMyStock() {
+            const resp = await fetch('/api/inventory', { headers: { 'Authorization': `Bearer ${token}` } });
+            const data = await resp.json();
+            dummyStockistData.myStock = data;
+            loadStockistMyStock();
         }
 
         // Populate dropdowns with products for order placement
@@ -1383,15 +1390,16 @@
             body.innerHTML = '';
             dummyStockistData.myStock.forEach(s => {
                 const row = document.createElement('tr');
+                const status = s.status || (s.quantity < 50 ? 'Low Stock' : 'Healthy');
                 let statusColor = 'inherit';
-                if (s.status === 'Low Stock') statusColor = '#ffc107';
+                if (status === 'Low Stock') statusColor = '#ffc107';
                 row.innerHTML = `
-                    <td>${s.product_name}</td>
-                    <td>${s.batch_no}</td>
+                    <td>${s.product_name || ''}</td>
+                    <td>${s.batch_no || ''}</td>
                     <td>${s.quantity}</td>
                     <td>${s.exp_date || ''}</td>
                     <td>${s.last_updated || ''}</td>
-                    <td style="color:${statusColor}; font-weight: 500;">${s.status}</td>
+                    <td style="color:${statusColor}; font-weight: 500;">${status}</td>
                 `;
                 body.appendChild(row);
             });


### PR DESCRIPTION
## Summary
- broaden inventory API to allow super stockist access
- fetch live inventory on stockist dashboard
- compute basic stock status and render table rows from API data

## Testing
- `python main.py` *(fails: ModuleNotFoundError: No module named 'flask' before installing requirements; after installing succeeded)*
- `pytest tests/` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68565cd39424832aaf9037992674f334