### PR TITLE
[Backend] Add pricing catalog API

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -10,6 +10,7 @@ from backend.routes.product import product_bp
 from backend.routes.inventory import inventory_bp
 from backend.routes.audit import audit_bp
 from backend.routes.sync import sync_bp
+from backend.routes.pricing import pricing_bp
 from backend.database import engine, SessionLocal
 from backend.models import Base
 from backend.models.order import Order  # ensure table registration
@@ -18,6 +19,7 @@ from backend.models.pack_config import PackConfig
 from backend.models.product import Product
 from backend.models.user import User
 from backend.models.inventory import Inventory
+from backend.models.pricing_catalog import PricingCatalog
 from backend.models.audit_log import AuditLog
 
 app = Flask(__name__, static_folder="../frontend", static_url_path="")
@@ -79,6 +81,7 @@ app.register_blueprint(product_bp, url_prefix="/api")
 app.register_blueprint(inventory_bp, url_prefix="/api")
 app.register_blueprint(audit_bp, url_prefix="/api")
 app.register_blueprint(sync_bp, url_prefix="/api")
+app.register_blueprint(pricing_bp, url_prefix="/api")
 
 
 @app.route("/")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -2,4 +2,5 @@ from sqlalchemy.orm import declarative_base
 
 Base = declarative_base()
 from .audit_log import AuditLog
+from .pricing_catalog import PricingCatalog
 

--- a/backend/models/pricing_catalog.py
+++ b/backend/models/pricing_catalog.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, Integer, Float, String, Date, ForeignKey
+from . import Base
+
+class PricingCatalog(Base):
+    __tablename__ = 'pricing_catalog'
+    id = Column(Integer, primary_key=True)
+    product_id = Column(Integer, ForeignKey('products.id'), nullable=False)
+    region = Column(String, nullable=False)
+    ptr = Column(Float, nullable=False)
+    pts = Column(Float, nullable=False)
+    effective_date = Column(Date, nullable=False)

--- a/backend/routes/pricing.py
+++ b/backend/routes/pricing.py
@@ -1,0 +1,133 @@
+from datetime import date
+from flask import Blueprint, request, jsonify
+from sqlalchemy.orm import Session
+from backend.auth import roles_required, role_required
+from backend.database import SessionLocal
+from backend.models.pricing_catalog import PricingCatalog
+from backend.models.product import Product
+from backend.models.audit_log import AuditLog
+
+
+def _parse_iso_date(value):
+    if isinstance(value, str) and value:
+        try:
+            return date.fromisoformat(value)
+        except ValueError:
+            return None
+    return value
+
+
+def log_event(session: Session, event_type: str, details: str):
+    log = AuditLog(event_type=event_type, details=details)
+    session.add(log)
+    session.commit()
+
+
+pricing_bp = Blueprint('pricing', __name__)
+
+
+@pricing_bp.route('/pricing', methods=['GET'])
+@roles_required('manufacturer', 'cfa', 'super_stockist')
+def list_pricing():
+    session: Session = SessionLocal()
+    region = request.args.get('region')
+    query = session.query(PricingCatalog, Product.name).join(Product, PricingCatalog.product_id == Product.id)
+    if region and region != 'all':
+        query = query.filter(PricingCatalog.region == region)
+    rows = query.all()
+    result = []
+    for p, name in rows:
+        result.append({
+            'id': p.id,
+            'product_id': p.product_id,
+            'product_name': name,
+            'region': p.region,
+            'ptr': p.ptr,
+            'pts': p.pts,
+            'effective_date': str(p.effective_date)
+        })
+    session.close()
+    return jsonify(result)
+
+
+@pricing_bp.route('/pricing', methods=['POST'])
+@role_required('manufacturer')
+def add_pricing():
+    session: Session = SessionLocal()
+    data = request.json or {}
+    product_id = data.get('product_id')
+    region = data.get('region')
+    ptr = data.get('ptr')
+    pts = data.get('pts')
+    effective_date = _parse_iso_date(data.get('effective_date'))
+    if not product_id or not region or ptr is None or pts is None or not effective_date:
+        session.close()
+        return jsonify({'error': 'Invalid pricing data'}), 400
+    record = PricingCatalog(
+        product_id=product_id,
+        region=region,
+        ptr=ptr,
+        pts=pts,
+        effective_date=effective_date
+    )
+    session.add(record)
+    session.commit()
+    log_event(session, 'pricing_added', f'Pricing {record.id} added for product {product_id}')
+    result = {
+        'id': record.id,
+        'product_id': record.product_id,
+        'region': record.region,
+        'ptr': record.ptr,
+        'pts': record.pts,
+        'effective_date': str(record.effective_date)
+    }
+    session.close()
+    return jsonify(result), 201
+
+
+@pricing_bp.route('/pricing/<int:pricing_id>', methods=['PUT'])
+@role_required('manufacturer')
+def update_pricing(pricing_id: int):
+    session: Session = SessionLocal()
+    record = session.query(PricingCatalog).get(pricing_id)
+    if not record:
+        session.close()
+        return jsonify({'error': 'Pricing not found'}), 404
+    data = request.json or {}
+    if 'product_id' in data:
+        record.product_id = data['product_id']
+    if 'region' in data:
+        record.region = data['region']
+    if 'ptr' in data:
+        record.ptr = data['ptr']
+    if 'pts' in data:
+        record.pts = data['pts']
+    if 'effective_date' in data:
+        record.effective_date = _parse_iso_date(data['effective_date'])
+    session.commit()
+    log_event(session, 'pricing_updated', f'Pricing {pricing_id} updated')
+    result = {
+        'id': record.id,
+        'product_id': record.product_id,
+        'region': record.region,
+        'ptr': record.ptr,
+        'pts': record.pts,
+        'effective_date': str(record.effective_date)
+    }
+    session.close()
+    return jsonify(result)
+
+
+@pricing_bp.route('/pricing/<int:pricing_id>', methods=['DELETE'])
+@role_required('manufacturer')
+def delete_pricing(pricing_id: int):
+    session: Session = SessionLocal()
+    record = session.query(PricingCatalog).get(pricing_id)
+    if not record:
+        session.close()
+        return jsonify({'error': 'Pricing not found'}), 404
+    session.delete(record)
+    session.commit()
+    log_event(session, 'pricing_deleted', f'Pricing {pricing_id} deleted')
+    session.close()
+    return jsonify({'message': 'deleted'})

--- a/frontend/cfa.html
+++ b/frontend/cfa.html
@@ -1408,6 +1408,7 @@
             loadDownstreamStockVisibility();
             loadCFAAuditLogs();
             populateProductDropdownsCFA();
+            document.getElementById('pricingStateRegionCFA').addEventListener('change', loadCFAPricing);
         });
 
         function openModal(modalId) {
@@ -1552,18 +1553,25 @@
         }
 
         // Load Pricing (View Only for CFA)
-        function loadCFAPricing() {
+        async function loadCFAPricing() {
             const body = document.getElementById('cfaPricingTableBody');
             if (!body) return;
             body.innerHTML = '';
-            dummyCFAData.pricing.forEach(p => {
+            let url = '/api/pricing';
+            const region = document.getElementById('pricingStateRegionCFA').value;
+            if (region && region !== 'all') {
+                url += `?region=${encodeURIComponent(region)}`;
+            }
+            const resp = await fetch(url, { headers: { 'Authorization': `Bearer ${token}` } });
+            const data = resp.ok ? await resp.json() : [];
+            data.forEach(p => {
                 const row = document.createElement('tr');
                 row.innerHTML = `
                     <td>${p.product_id}</td>
                     <td>${p.product_name}</td>
-                    <td>${p.state_region}</td>
-                    <td>${p.ptr.toFixed(2)}</td>
-                    <td>${p.pts.toFixed(2)}</td>
+                    <td>${p.region}</td>
+                    <td>${p.ptr}</td>
+                    <td>${p.pts}</td>
                     <td>${p.effective_date}</td>
                 `;
                 body.appendChild(row);

--- a/frontend/manufacterer.html
+++ b/frontend/manufacterer.html
@@ -1474,8 +1474,22 @@
     <div id="addPriceModal" class="modal">
         <div class="modal-content">
             <div class="modal-header"><h3>Add/Edit Price Rule</h3><span class="close-btn" onclick="closeModal('addPriceModal')">&times;</span></div>
-            <p>Form for adding/editing price rule goes here...</p>
-            <div class="modal-footer"><button type="button" class="btn btn-secondary" onclick="closeModal('addPriceModal')">Cancel</button><button type="submit" class="btn btn-success">Save Price</button></div>
+            <form id="priceForm">
+                <label>Product</label>
+                <select id="priceProductId"></select>
+                <label>Region/State</label>
+                <input type="text" id="priceRegion" required>
+                <label>PTR</label>
+                <input type="number" step="0.01" id="pricePTR" required>
+                <label>PTS</label>
+                <input type="number" step="0.01" id="pricePTS" required>
+                <label>Effective Date</label>
+                <input type="date" id="priceEffective" required>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" onclick="closeModal('addPriceModal')">Cancel</button>
+                    <button type="submit" class="btn btn-success">Save Price</button>
+                </div>
+            </form>
         </div>
     </div>
     <div id="assignCfaModal" class="modal">
@@ -1748,7 +1762,7 @@
         }
 
         function populateProductDropdowns(products) {
-            const selects = ['batchProductId','editBatchProductId','packProductId','editPackProductId'];
+            const selects = ['batchProductId','editBatchProductId','packProductId','editPackProductId','priceProductId'];
             selects.forEach(id => {
                 const sel = document.getElementById(id);
                 if (sel) {
@@ -1954,6 +1968,30 @@
             });
         }
 
+        async function loadPricing() {
+            let url = '/api/pricing';
+            const region = document.getElementById('pricingStateRegion').value;
+            if (region && region !== 'all') {
+                url += `?region=${encodeURIComponent(region)}`;
+            }
+            const resp = await fetch(url, { headers: { 'Authorization': `Bearer ${token}` } });
+            const data = resp.ok ? await resp.json() : [];
+            const body = document.getElementById('pricingTableBody');
+            body.innerHTML = '';
+            data.forEach(p => {
+                const row = document.createElement('tr');
+                row.innerHTML = `
+                    <td>${p.product_id}</td>
+                    <td>${p.product_name || ''}</td>
+                    <td>${p.region}</td>
+                    <td>${p.ptr}</td>
+                    <td>${p.pts}</td>
+                    <td>${p.effective_date}</td>
+                    <td></td>`;
+                body.appendChild(row);
+            });
+        }
+
         async function loadOrders() {
             const resp = await fetch('/api/orders?status=approval_requested', { headers: { 'Authorization': `Bearer ${token}` } });
             const data = await resp.json();
@@ -2004,10 +2042,32 @@
         loadProducts();
         loadBatches();
         loadPackConfigs();
+        loadPricing();
         loadOrders();
         loadLiveStock();
         loadUsers();
         loadAuditLogs();
+
+        document.getElementById('pricingStateRegion').addEventListener('change', loadPricing);
+        document.getElementById('priceForm').addEventListener('submit', async function(e) {
+            e.preventDefault();
+            const payload = {
+                product_id: document.getElementById('priceProductId').value,
+                region: document.getElementById('priceRegion').value,
+                ptr: parseFloat(document.getElementById('pricePTR').value),
+                pts: parseFloat(document.getElementById('pricePTS').value),
+                effective_date: document.getElementById('priceEffective').value
+            };
+            const resp = await fetch('/api/pricing', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+                body: JSON.stringify(payload)
+            });
+            if (resp.ok) {
+                closeModal('addPriceModal');
+                await loadPricing();
+            }
+        });
 
         document.getElementById('userForm').addEventListener('submit', async function(e) {
             e.preventDefault();

--- a/frontend/stockist.html
+++ b/frontend/stockist.html
@@ -1222,6 +1222,7 @@
             loadStockistPricing();
             fetchMyStock();
             loadStockistAuditLogs();
+            document.getElementById('pricingStateRegionStockist').addEventListener('change', loadStockistPricing);
         });
 
         // Modals are not used for Stockist in this simplified version, as forms are directly on page sections.
@@ -1352,18 +1353,25 @@
         }
 
         // Load Pricing (View Only for Stockist)
-        function loadStockistPricing() {
+        async function loadStockistPricing() {
             const body = document.getElementById('stockistPricingTableBody');
             if (!body) return;
             body.innerHTML = '';
-            dummyStockistData.pricing.forEach(p => {
+            let url = '/api/pricing';
+            const region = document.getElementById('pricingStateRegionStockist').value;
+            if (region && region !== 'all') {
+                url += `?region=${encodeURIComponent(region)}`;
+            }
+            const resp = await fetch(url, { headers: { 'Authorization': `Bearer ${token}` } });
+            const data = resp.ok ? await resp.json() : [];
+            data.forEach(p => {
                 const row = document.createElement('tr');
                 row.innerHTML = `
                     <td>${p.product_id}</td>
                     <td>${p.product_name}</td>
-                    <td>${p.state_region}</td>
-                    <td>${p.ptr.toFixed(2)}</td>
-                    <td>${p.pts.toFixed(2)}</td>
+                    <td>${p.region}</td>
+                    <td>${p.ptr}</td>
+                    <td>${p.pts}</td>
                     <td>${p.effective_date}</td>
                 `;
                 body.appendChild(row);


### PR DESCRIPTION
## Summary
- introduce PricingCatalog model
- implement CRUD endpoints for `/api/pricing`
- register new pricing routes
- fetch pricing catalogs in dashboards
- allow manufacturers to add pricing rules

## Testing
- `python main.py` *(fails: port already in use, then started on port 8001)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856ff6dadcc832a8a395e510190b339