### PR TITLE
[Backend] Add recall management module

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -11,6 +11,7 @@ from backend.routes.inventory import inventory_bp
 from backend.routes.audit import audit_bp
 from backend.routes.sync import sync_bp
 from backend.routes.pricing import pricing_bp
+from backend.routes.recall import recall_bp
 from backend.database import engine, SessionLocal
 from backend.models import Base
 from backend.models.order import Order  # ensure table registration
@@ -21,6 +22,7 @@ from backend.models.user import User
 from backend.models.inventory import Inventory
 from backend.models.pricing_catalog import PricingCatalog
 from backend.models.audit_log import AuditLog
+from backend.models.recall import Recall
 
 app = Flask(__name__, static_folder="../frontend", static_url_path="")
 
@@ -82,6 +84,7 @@ app.register_blueprint(inventory_bp, url_prefix="/api")
 app.register_blueprint(audit_bp, url_prefix="/api")
 app.register_blueprint(sync_bp, url_prefix="/api")
 app.register_blueprint(pricing_bp, url_prefix="/api")
+app.register_blueprint(recall_bp, url_prefix="/api")
 
 
 @app.route("/")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -3,4 +3,5 @@ from sqlalchemy.orm import declarative_base
 Base = declarative_base()
 from .audit_log import AuditLog
 from .pricing_catalog import PricingCatalog
+from .recall import Recall
 

--- a/backend/models/recall.py
+++ b/backend/models/recall.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, Integer, String, Date
+from . import Base
+
+class Recall(Base):
+    __tablename__ = 'recalls'
+    id = Column(Integer, primary_key=True)
+    batch_no = Column(String, nullable=False)
+    reason = Column(String, nullable=False)
+    start_date = Column(Date, nullable=False)
+    status = Column(String, default='active')

--- a/backend/routes/recall.py
+++ b/backend/routes/recall.py
@@ -1,0 +1,94 @@
+from datetime import date
+from flask import Blueprint, request, jsonify
+from sqlalchemy.orm import Session
+from backend.auth import role_required, roles_required
+from backend.database import SessionLocal
+from backend.models.recall import Recall
+from backend.models.product import Product
+from backend.models.batch import Batch
+from backend.models.audit_log import AuditLog
+
+recall_bp = Blueprint('recall', __name__)
+
+
+def log_event(session: Session, event_type: str, details: str):
+    log = AuditLog(event_type=event_type, details=details)
+    session.add(log)
+    session.commit()
+
+
+@recall_bp.route('/recalls', methods=['GET'])
+@roles_required('manufacturer', 'cfa', 'super_stockist')
+def list_recalls():
+    session: Session = SessionLocal()
+    status = request.args.get('status')
+    query = session.query(Recall, Batch.product_id, Product.name).\
+        join(Batch, Recall.batch_no == Batch.batch_no).\
+        join(Product, Batch.product_id == Product.id)
+    if status:
+        query = query.filter(Recall.status == status)
+    rows = query.all()
+    result = []
+    for r, product_id, product_name in rows:
+        result.append({
+            'id': r.id,
+            'batch_no': r.batch_no,
+            'product_id': product_id,
+            'product_name': product_name,
+            'reason': r.reason,
+            'start_date': str(r.start_date),
+            'status': r.status
+        })
+    session.close()
+    return jsonify(result)
+
+
+@recall_bp.route('/recalls', methods=['POST'])
+@role_required('manufacturer')
+def create_recall():
+    session: Session = SessionLocal()
+    data = request.json or {}
+    batch_no = data.get('batch_no')
+    reason = data.get('reason')
+    if not batch_no or not reason:
+        session.close()
+        return jsonify({'error': 'Invalid recall data'}), 400
+    recall = Recall(batch_no=batch_no, reason=reason, start_date=date.today(), status='active')
+    session.add(recall)
+    session.commit()
+    log_event(session, 'recall_created', f'Recall {recall.id} started for batch {batch_no}')
+    result = {
+        'id': recall.id,
+        'batch_no': recall.batch_no,
+        'reason': recall.reason,
+        'start_date': str(recall.start_date),
+        'status': recall.status
+    }
+    session.close()
+    return jsonify(result), 201
+
+
+@recall_bp.route('/recalls/<int:recall_id>', methods=['PUT'])
+@role_required('manufacturer')
+def update_recall(recall_id: int):
+    session: Session = SessionLocal()
+    recall = session.query(Recall).get(recall_id)
+    if not recall:
+        session.close()
+        return jsonify({'error': 'Recall not found'}), 404
+    data = request.json or {}
+    if 'status' in data:
+        recall.status = data['status']
+    if 'reason' in data:
+        recall.reason = data['reason']
+    session.commit()
+    log_event(session, 'recall_updated', f'Recall {recall_id} updated')
+    result = {
+        'id': recall.id,
+        'batch_no': recall.batch_no,
+        'reason': recall.reason,
+        'start_date': str(recall.start_date),
+        'status': recall.status
+    }
+    session.close()
+    return jsonify(result)

--- a/frontend/manufacterer.html
+++ b/frontend/manufacterer.html
@@ -2047,6 +2047,7 @@
         loadLiveStock();
         loadUsers();
         loadAuditLogs();
+        loadRecalls();
 
         document.getElementById('pricingStateRegion').addEventListener('change', loadPricing);
         document.getElementById('priceForm').addEventListener('submit', async function(e) {
@@ -2125,6 +2126,42 @@
                     <td></td>
                     <td>${log.details}</td>
                     <td></td>`;
+                body.appendChild(row);
+            });
+        }
+
+        document.getElementById('recallForm').addEventListener('submit', async function(e) {
+            e.preventDefault();
+            const payload = {
+                batch_no: document.getElementById('recallBatchNo').value,
+                reason: document.getElementById('recallReason').value
+            };
+            const resp = await fetch('/api/recalls', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+                body: JSON.stringify(payload)
+            });
+            if (resp.ok) {
+                document.getElementById('recallForm').reset();
+                await loadRecalls();
+            }
+        });
+
+        async function loadRecalls() {
+            const resp = await fetch('/api/recalls', { headers: { 'Authorization': `Bearer ${token}` } });
+            const data = resp.ok ? await resp.json() : [];
+            const body = document.getElementById('recallHistoryTableBody');
+            if (!body) return;
+            body.innerHTML = '';
+            data.forEach(r => {
+                const row = document.createElement('tr');
+                row.innerHTML = `
+                    <td>${r.id}</td>
+                    <td>${r.batch_no}</td>
+                    <td>${r.product_name || ''}</td>
+                    <td>${r.reason}</td>
+                    <td>${r.start_date}</td>
+                    <td>${r.status}</td>`;
                 body.appendChild(row);
             });
         }


### PR DESCRIPTION
## Summary
- add `recall` table model
- create `/api/recalls` API for listing and creating recalls
- register blueprint in application
- fetch recalls in manufacturer dashboard

## Testing
- `python main.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pytest tests/` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857060608e8832a8bfca5871995c3a3