### PR TITLE
[Backend] Add new APIs for stock movement and pack configs

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -12,6 +12,8 @@ from backend.routes.audit import audit_bp
 from backend.routes.sync import sync_bp
 from backend.routes.pricing import pricing_bp
 from backend.routes.recall import recall_bp
+from backend.routes.pack_config import pack_config_bp
+from backend.routes.cfa_stock import cfa_stock_bp
 from backend.database import engine, SessionLocal
 from backend.models import Base
 from backend.models.order import Order  # ensure table registration
@@ -23,6 +25,7 @@ from backend.models.inventory import Inventory
 from backend.models.pricing_catalog import PricingCatalog
 from backend.models.audit_log import AuditLog
 from backend.models.recall import Recall
+from backend.models.cfa_stock_movement import CFAStockMovement
 
 app = Flask(__name__, static_folder="../frontend", static_url_path="")
 
@@ -85,6 +88,8 @@ app.register_blueprint(audit_bp, url_prefix="/api")
 app.register_blueprint(sync_bp, url_prefix="/api")
 app.register_blueprint(pricing_bp, url_prefix="/api")
 app.register_blueprint(recall_bp, url_prefix="/api")
+app.register_blueprint(pack_config_bp, url_prefix="/api")
+app.register_blueprint(cfa_stock_bp, url_prefix="/api")
 
 
 @app.route("/")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -4,4 +4,5 @@ Base = declarative_base()
 from .audit_log import AuditLog
 from .pricing_catalog import PricingCatalog
 from .recall import Recall
+from .cfa_stock_movement import CFAStockMovement
 

--- a/backend/models/audit_log.py
+++ b/backend/models/audit_log.py
@@ -7,5 +7,7 @@ class AuditLog(Base):
     id = Column(Integer, primary_key=True)
     event_type = Column(String, nullable=False)
     details = Column(String, nullable=False)
+    username = Column(String, nullable=True)
+    role = Column(String, nullable=True)
     timestamp = Column(DateTime, default=datetime.utcnow)
 

--- a/backend/models/cfa_stock_movement.py
+++ b/backend/models/cfa_stock_movement.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+from datetime import datetime
+from . import Base
+
+class CFAStockMovement(Base):
+    __tablename__ = 'cfa_stock_movements'
+    id = Column(Integer, primary_key=True)
+    cfa = Column(String, nullable=False)
+    product_id = Column(Integer, ForeignKey('products.id'), nullable=False)
+    batch_no = Column(String, nullable=False)
+    quantity = Column(Integer, nullable=False)
+    action = Column(String, nullable=False)  # received or dispatched
+    timestamp = Column(DateTime, default=datetime.utcnow)

--- a/backend/routes/audit.py
+++ b/backend/routes/audit.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, request, jsonify
 from sqlalchemy.orm import Session
 from backend.auth import roles_required
 from backend.database import SessionLocal
@@ -10,12 +10,21 @@ audit_bp = Blueprint('audit', __name__)
 @roles_required('manufacturer', 'cfa', 'super_stockist')
 def get_logs():
     session: Session = SessionLocal()
-    logs = session.query(AuditLog).order_by(AuditLog.timestamp.desc()).limit(100).all()
+    query = session.query(AuditLog)
+    role_filter = request.args.get('role')
+    user_filter = request.args.get('user')
+    if role_filter:
+        query = query.filter(AuditLog.role == role_filter)
+    if user_filter:
+        query = query.filter(AuditLog.username == user_filter)
+    logs = query.order_by(AuditLog.timestamp.desc()).limit(100).all()
     result = [
         {
             'id': log.id,
             'event_type': log.event_type,
             'details': log.details,
+            'username': log.username,
+            'role': log.role,
             'timestamp': log.timestamp.isoformat()
         }
         for log in logs

--- a/backend/routes/cfa_stock.py
+++ b/backend/routes/cfa_stock.py
@@ -1,0 +1,73 @@
+from flask import Blueprint, request, jsonify
+from sqlalchemy.orm import Session
+from backend.auth import role_required
+from backend.database import SessionLocal
+from backend.models.cfa_stock_movement import CFAStockMovement
+from backend.models.audit_log import AuditLog
+
+
+def log_event(session: Session, event_type: str, details: str):
+    username = getattr(request, 'user', {}).get('username') if hasattr(request, 'user') else None
+    role = getattr(request, 'user', {}).get('role') if hasattr(request, 'user') else None
+    log = AuditLog(event_type=event_type, details=details, username=username, role=role)
+    session.add(log)
+    session.commit()
+
+
+cfa_stock_bp = Blueprint('cfa_stock', __name__)
+
+
+@cfa_stock_bp.route('/cfa/stock', methods=['GET', 'POST'])
+@role_required('cfa')
+def stock_movements():
+    session: Session = SessionLocal()
+    if request.method == 'POST':
+        data = request.json or {}
+        product_id = data.get('product_id')
+        batch_no = data.get('batch_no')
+        quantity = data.get('quantity')
+        action = data.get('action')
+        if not product_id or not batch_no or quantity is None or action not in ('received', 'dispatched'):
+            session.close()
+            return jsonify({'error': 'Invalid stock movement data'}), 400
+        movement = CFAStockMovement(
+            cfa=request.user['username'],
+            product_id=product_id,
+            batch_no=batch_no,
+            quantity=quantity,
+            action=action
+        )
+        session.add(movement)
+        session.commit()
+        log_event(session, f'cfa_stock_{action}', f'{quantity} units {action} for product {product_id} batch {batch_no}')
+        result = {
+            'id': movement.id,
+            'cfa': movement.cfa,
+            'product_id': movement.product_id,
+            'batch_no': movement.batch_no,
+            'quantity': movement.quantity,
+            'action': movement.action,
+            'timestamp': movement.timestamp.isoformat()
+        }
+        session.close()
+        return jsonify(result), 201
+
+    query = session.query(CFAStockMovement).filter(CFAStockMovement.cfa == request.user['username'])
+    action_filter = request.args.get('action')
+    if action_filter:
+        query = query.filter(CFAStockMovement.action == action_filter)
+    movements = query.order_by(CFAStockMovement.timestamp.desc()).all()
+    result = [
+        {
+            'id': m.id,
+            'cfa': m.cfa,
+            'product_id': m.product_id,
+            'batch_no': m.batch_no,
+            'quantity': m.quantity,
+            'action': m.action,
+            'timestamp': m.timestamp.isoformat()
+        }
+        for m in movements
+    ]
+    session.close()
+    return jsonify(result)

--- a/backend/routes/inventory.py
+++ b/backend/routes/inventory.py
@@ -19,7 +19,9 @@ def _parse_iso_date(value):
 
 
 def log_event(session: Session, event_type: str, details: str):
-    log = AuditLog(event_type=event_type, details=details)
+    username = getattr(request, 'user', {}).get('username') if hasattr(request, 'user') else None
+    role = getattr(request, 'user', {}).get('role') if hasattr(request, 'user') else None
+    log = AuditLog(event_type=event_type, details=details, username=username, role=role)
     session.add(log)
     session.commit()
 

--- a/backend/routes/order.py
+++ b/backend/routes/order.py
@@ -20,8 +20,10 @@ def _parse_iso_date(value):
 
 
 def log_event(session: Session, event_type: str, details: str):
-    """Create an audit log entry."""
-    log = AuditLog(event_type=event_type, details=details)
+    """Create an audit log entry including user context."""
+    username = getattr(request, 'user', {}).get('username') if hasattr(request, 'user') else None
+    role = getattr(request, 'user', {}).get('role') if hasattr(request, 'user') else None
+    log = AuditLog(event_type=event_type, details=details, username=username, role=role)
     session.add(log)
     session.commit()
 

--- a/backend/routes/pack_config.py
+++ b/backend/routes/pack_config.py
@@ -1,0 +1,98 @@
+from flask import Blueprint, request, jsonify
+from sqlalchemy.orm import Session
+from backend.auth import role_required, roles_required
+from backend.database import SessionLocal
+from backend.models.pack_config import PackConfig
+from backend.models.audit_log import AuditLog
+
+
+def log_event(session: Session, event_type: str, details: str):
+    username = getattr(request, 'user', {}).get('username') if hasattr(request, 'user') else None
+    role = getattr(request, 'user', {}).get('role') if hasattr(request, 'user') else None
+    log = AuditLog(event_type=event_type, details=details, username=username, role=role)
+    session.add(log)
+    session.commit()
+
+
+pack_config_bp = Blueprint('pack_config', __name__)
+
+
+@pack_config_bp.route('/pack-configs', methods=['GET'])
+@roles_required('manufacturer', 'cfa', 'super_stockist')
+def list_configs():
+    session: Session = SessionLocal()
+    configs = session.query(PackConfig).all()
+    result = [
+        {
+            'id': c.id,
+            'product_id': c.product_id,
+            'pack_type': c.pack_type,
+            'units_per_pack': c.units_per_pack,
+            'dimensions': c.dimensions,
+        }
+        for c in configs
+    ]
+    session.close()
+    return jsonify(result)
+
+
+@pack_config_bp.route('/pack-configs', methods=['POST'])
+@role_required('manufacturer')
+def add_config():
+    session: Session = SessionLocal()
+    data = request.json or {}
+    product_id = data.get('product_id')
+    pack_type = data.get('pack_type')
+    if not product_id or not pack_type:
+        session.close()
+        return jsonify({'error': 'Invalid pack config data'}), 400
+    config = PackConfig(
+        product_id=product_id,
+        pack_type=pack_type,
+        units_per_pack=data.get('units_per_pack'),
+        dimensions=data.get('dimensions'),
+    )
+    session.add(config)
+    session.commit()
+    log_event(session, 'pack_config_created', f'Pack config {config.id} created')
+    result = {
+        'id': config.id,
+        'product_id': config.product_id,
+        'pack_type': config.pack_type,
+        'units_per_pack': config.units_per_pack,
+        'dimensions': config.dimensions,
+    }
+    session.close()
+    return jsonify(result), 201
+
+
+@pack_config_bp.route('/pack-configs/<int:config_id>', methods=['PUT', 'DELETE'])
+@role_required('manufacturer')
+def modify_config(config_id: int):
+    session: Session = SessionLocal()
+    config = session.query(PackConfig).get(config_id)
+    if not config:
+        session.close()
+        return jsonify({'error': 'Pack config not found'}), 404
+    if request.method == 'DELETE':
+        session.delete(config)
+        session.commit()
+        log_event(session, 'pack_config_deleted', f'Pack config {config_id} deleted')
+        session.close()
+        return jsonify({'message': 'deleted'})
+    data = request.json or {}
+    config.product_id = data.get('product_id', config.product_id)
+    config.pack_type = data.get('pack_type', config.pack_type)
+    config.units_per_pack = data.get('units_per_pack', config.units_per_pack)
+    config.dimensions = data.get('dimensions', config.dimensions)
+    session.commit()
+    log_event(session, 'pack_config_updated', f'Pack config {config_id} updated')
+    result = {
+        'id': config.id,
+        'product_id': config.product_id,
+        'pack_type': config.pack_type,
+        'units_per_pack': config.units_per_pack,
+        'dimensions': config.dimensions,
+    }
+    session.close()
+    return jsonify(result)

--- a/backend/routes/pricing.py
+++ b/backend/routes/pricing.py
@@ -18,7 +18,9 @@ def _parse_iso_date(value):
 
 
 def log_event(session: Session, event_type: str, details: str):
-    log = AuditLog(event_type=event_type, details=details)
+    username = getattr(request, 'user', {}).get('username') if hasattr(request, 'user') else None
+    role = getattr(request, 'user', {}).get('role') if hasattr(request, 'user') else None
+    log = AuditLog(event_type=event_type, details=details, username=username, role=role)
     session.add(log)
     session.commit()
 

--- a/backend/routes/recall.py
+++ b/backend/routes/recall.py
@@ -12,7 +12,9 @@ recall_bp = Blueprint('recall', __name__)
 
 
 def log_event(session: Session, event_type: str, details: str):
-    log = AuditLog(event_type=event_type, details=details)
+    username = getattr(request, 'user', {}).get('username') if hasattr(request, 'user') else None
+    role = getattr(request, 'user', {}).get('role') if hasattr(request, 'user') else None
+    log = AuditLog(event_type=event_type, details=details, username=username, role=role)
     session.add(log)
     session.commit()
 


### PR DESCRIPTION
## Summary
- create CFA stock movement model and endpoints
- expose pack-config CRUD at `/api/pack-configs`
- extend audit logs with filtering capability
- log username/role for all audit events
- register new blueprints in backend app

## Testing
- `pip install -r backend/requirements.txt`
- `python main.py` *(fails: port already in use)*
- `PORT=8001 nohup python main.py` *(server started)*
- `curl -X POST http://127.0.0.1:8001/api/auth/login -d '{"username":"admin","password":"adminpass"}' -H 'Content-Type: application/json'`
- `curl -H 'Authorization: Bearer <token>' http://127.0.0.1:8001/api/pack-configs`
- `curl -X POST http://127.0.0.1:8001/api/cfa/stock ...`
- `pytest tests` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68570ce70270832a83ee9f618b2070a7