### PR TITLE
[Frontend] Hook dashboards to new APIs

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -12,6 +12,8 @@ from backend.routes.audit import audit_bp
 from backend.routes.sync import sync_bp
 from backend.routes.pricing import pricing_bp
 from backend.routes.recall import recall_bp
+from backend.routes.pack_config import pack_config_bp
+from backend.routes.cfa_stock import cfa_stock_bp
 from backend.database import engine, SessionLocal
 from backend.models import Base
 from backend.models.order import Order  # ensure table registration
@@ -23,6 +25,7 @@ from backend.models.inventory import Inventory
 from backend.models.pricing_catalog import PricingCatalog
 from backend.models.audit_log import AuditLog
 from backend.models.recall import Recall
+from backend.models.cfa_stock_movement import CFAStockMovement
 
 app = Flask(__name__, static_folder="../frontend", static_url_path="")
 
@@ -85,6 +88,8 @@ app.register_blueprint(audit_bp, url_prefix="/api")
 app.register_blueprint(sync_bp, url_prefix="/api")
 app.register_blueprint(pricing_bp, url_prefix="/api")
 app.register_blueprint(recall_bp, url_prefix="/api")
+app.register_blueprint(pack_config_bp, url_prefix="/api")
+app.register_blueprint(cfa_stock_bp, url_prefix="/api")
 
 
 @app.route("/")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -4,4 +4,5 @@ Base = declarative_base()
 from .audit_log import AuditLog
 from .pricing_catalog import PricingCatalog
 from .recall import Recall
+from .cfa_stock_movement import CFAStockMovement
 

--- a/backend/models/audit_log.py
+++ b/backend/models/audit_log.py
@@ -7,5 +7,7 @@ class AuditLog(Base):
     id = Column(Integer, primary_key=True)
     event_type = Column(String, nullable=False)
     details = Column(String, nullable=False)
+    username = Column(String, nullable=True)
+    role = Column(String, nullable=True)
     timestamp = Column(DateTime, default=datetime.utcnow)
 

--- a/backend/models/cfa_stock_movement.py
+++ b/backend/models/cfa_stock_movement.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+from datetime import datetime
+from . import Base
+
+class CFAStockMovement(Base):
+    __tablename__ = 'cfa_stock_movements'
+    id = Column(Integer, primary_key=True)
+    cfa = Column(String, nullable=False)
+    product_id = Column(Integer, ForeignKey('products.id'), nullable=False)
+    batch_no = Column(String, nullable=False)
+    quantity = Column(Integer, nullable=False)
+    action = Column(String, nullable=False)  # received or dispatched
+    timestamp = Column(DateTime, default=datetime.utcnow)

--- a/backend/routes/audit.py
+++ b/backend/routes/audit.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, request, jsonify
 from sqlalchemy.orm import Session
 from backend.auth import roles_required
 from backend.database import SessionLocal
@@ -10,12 +10,21 @@ audit_bp = Blueprint('audit', __name__)
 @roles_required('manufacturer', 'cfa', 'super_stockist')
 def get_logs():
     session: Session = SessionLocal()
-    logs = session.query(AuditLog).order_by(AuditLog.timestamp.desc()).limit(100).all()
+    query = session.query(AuditLog)
+    role_filter = request.args.get('role')
+    user_filter = request.args.get('user')
+    if role_filter:
+        query = query.filter(AuditLog.role == role_filter)
+    if user_filter:
+        query = query.filter(AuditLog.username == user_filter)
+    logs = query.order_by(AuditLog.timestamp.desc()).limit(100).all()
     result = [
         {
             'id': log.id,
             'event_type': log.event_type,
             'details': log.details,
+            'username': log.username,
+            'role': log.role,
             'timestamp': log.timestamp.isoformat()
         }
         for log in logs

--- a/backend/routes/cfa_stock.py
+++ b/backend/routes/cfa_stock.py
@@ -1,0 +1,73 @@
+from flask import Blueprint, request, jsonify
+from sqlalchemy.orm import Session
+from backend.auth import role_required
+from backend.database import SessionLocal
+from backend.models.cfa_stock_movement import CFAStockMovement
+from backend.models.audit_log import AuditLog
+
+
+def log_event(session: Session, event_type: str, details: str):
+    username = getattr(request, 'user', {}).get('username') if hasattr(request, 'user') else None
+    role = getattr(request, 'user', {}).get('role') if hasattr(request, 'user') else None
+    log = AuditLog(event_type=event_type, details=details, username=username, role=role)
+    session.add(log)
+    session.commit()
+
+
+cfa_stock_bp = Blueprint('cfa_stock', __name__)
+
+
+@cfa_stock_bp.route('/cfa/stock', methods=['GET', 'POST'])
+@role_required('cfa')
+def stock_movements():
+    session: Session = SessionLocal()
+    if request.method == 'POST':
+        data = request.json or {}
+        product_id = data.get('product_id')
+        batch_no = data.get('batch_no')
+        quantity = data.get('quantity')
+        action = data.get('action')
+        if not product_id or not batch_no or quantity is None or action not in ('received', 'dispatched'):
+            session.close()
+            return jsonify({'error': 'Invalid stock movement data'}), 400
+        movement = CFAStockMovement(
+            cfa=request.user['username'],
+            product_id=product_id,
+            batch_no=batch_no,
+            quantity=quantity,
+            action=action
+        )
+        session.add(movement)
+        session.commit()
+        log_event(session, f'cfa_stock_{action}', f'{quantity} units {action} for product {product_id} batch {batch_no}')
+        result = {
+            'id': movement.id,
+            'cfa': movement.cfa,
+            'product_id': movement.product_id,
+            'batch_no': movement.batch_no,
+            'quantity': movement.quantity,
+            'action': movement.action,
+            'timestamp': movement.timestamp.isoformat()
+        }
+        session.close()
+        return jsonify(result), 201
+
+    query = session.query(CFAStockMovement).filter(CFAStockMovement.cfa == request.user['username'])
+    action_filter = request.args.get('action')
+    if action_filter:
+        query = query.filter(CFAStockMovement.action == action_filter)
+    movements = query.order_by(CFAStockMovement.timestamp.desc()).all()
+    result = [
+        {
+            'id': m.id,
+            'cfa': m.cfa,
+            'product_id': m.product_id,
+            'batch_no': m.batch_no,
+            'quantity': m.quantity,
+            'action': m.action,
+            'timestamp': m.timestamp.isoformat()
+        }
+        for m in movements
+    ]
+    session.close()
+    return jsonify(result)

--- a/backend/routes/inventory.py
+++ b/backend/routes/inventory.py
@@ -19,7 +19,9 @@ def _parse_iso_date(value):
 
 
 def log_event(session: Session, event_type: str, details: str):
-    log = AuditLog(event_type=event_type, details=details)
+    username = getattr(request, 'user', {}).get('username') if hasattr(request, 'user') else None
+    role = getattr(request, 'user', {}).get('role') if hasattr(request, 'user') else None
+    log = AuditLog(event_type=event_type, details=details, username=username, role=role)
     session.add(log)
     session.commit()
 

--- a/backend/routes/order.py
+++ b/backend/routes/order.py
@@ -20,8 +20,10 @@ def _parse_iso_date(value):
 
 
 def log_event(session: Session, event_type: str, details: str):
-    """Create an audit log entry."""
-    log = AuditLog(event_type=event_type, details=details)
+    """Create an audit log entry including user context."""
+    username = getattr(request, 'user', {}).get('username') if hasattr(request, 'user') else None
+    role = getattr(request, 'user', {}).get('role') if hasattr(request, 'user') else None
+    log = AuditLog(event_type=event_type, details=details, username=username, role=role)
     session.add(log)
     session.commit()
 

--- a/backend/routes/pack_config.py
+++ b/backend/routes/pack_config.py
@@ -1,0 +1,98 @@
+from flask import Blueprint, request, jsonify
+from sqlalchemy.orm import Session
+from backend.auth import role_required, roles_required
+from backend.database import SessionLocal
+from backend.models.pack_config import PackConfig
+from backend.models.audit_log import AuditLog
+
+
+def log_event(session: Session, event_type: str, details: str):
+    username = getattr(request, 'user', {}).get('username') if hasattr(request, 'user') else None
+    role = getattr(request, 'user', {}).get('role') if hasattr(request, 'user') else None
+    log = AuditLog(event_type=event_type, details=details, username=username, role=role)
+    session.add(log)
+    session.commit()
+
+
+pack_config_bp = Blueprint('pack_config', __name__)
+
+
+@pack_config_bp.route('/pack-configs', methods=['GET'])
+@roles_required('manufacturer', 'cfa', 'super_stockist')
+def list_configs():
+    session: Session = SessionLocal()
+    configs = session.query(PackConfig).all()
+    result = [
+        {
+            'id': c.id,
+            'product_id': c.product_id,
+            'pack_type': c.pack_type,
+            'units_per_pack': c.units_per_pack,
+            'dimensions': c.dimensions,
+        }
+        for c in configs
+    ]
+    session.close()
+    return jsonify(result)
+
+
+@pack_config_bp.route('/pack-configs', methods=['POST'])
+@role_required('manufacturer')
+def add_config():
+    session: Session = SessionLocal()
+    data = request.json or {}
+    product_id = data.get('product_id')
+    pack_type = data.get('pack_type')
+    if not product_id or not pack_type:
+        session.close()
+        return jsonify({'error': 'Invalid pack config data'}), 400
+    config = PackConfig(
+        product_id=product_id,
+        pack_type=pack_type,
+        units_per_pack=data.get('units_per_pack'),
+        dimensions=data.get('dimensions'),
+    )
+    session.add(config)
+    session.commit()
+    log_event(session, 'pack_config_created', f'Pack config {config.id} created')
+    result = {
+        'id': config.id,
+        'product_id': config.product_id,
+        'pack_type': config.pack_type,
+        'units_per_pack': config.units_per_pack,
+        'dimensions': config.dimensions,
+    }
+    session.close()
+    return jsonify(result), 201
+
+
+@pack_config_bp.route('/pack-configs/<int:config_id>', methods=['PUT', 'DELETE'])
+@role_required('manufacturer')
+def modify_config(config_id: int):
+    session: Session = SessionLocal()
+    config = session.query(PackConfig).get(config_id)
+    if not config:
+        session.close()
+        return jsonify({'error': 'Pack config not found'}), 404
+    if request.method == 'DELETE':
+        session.delete(config)
+        session.commit()
+        log_event(session, 'pack_config_deleted', f'Pack config {config_id} deleted')
+        session.close()
+        return jsonify({'message': 'deleted'})
+    data = request.json or {}
+    config.product_id = data.get('product_id', config.product_id)
+    config.pack_type = data.get('pack_type', config.pack_type)
+    config.units_per_pack = data.get('units_per_pack', config.units_per_pack)
+    config.dimensions = data.get('dimensions', config.dimensions)
+    session.commit()
+    log_event(session, 'pack_config_updated', f'Pack config {config_id} updated')
+    result = {
+        'id': config.id,
+        'product_id': config.product_id,
+        'pack_type': config.pack_type,
+        'units_per_pack': config.units_per_pack,
+        'dimensions': config.dimensions,
+    }
+    session.close()
+    return jsonify(result)

--- a/backend/routes/pricing.py
+++ b/backend/routes/pricing.py
@@ -18,7 +18,9 @@ def _parse_iso_date(value):
 
 
 def log_event(session: Session, event_type: str, details: str):
-    log = AuditLog(event_type=event_type, details=details)
+    username = getattr(request, 'user', {}).get('username') if hasattr(request, 'user') else None
+    role = getattr(request, 'user', {}).get('role') if hasattr(request, 'user') else None
+    log = AuditLog(event_type=event_type, details=details, username=username, role=role)
     session.add(log)
     session.commit()
 

--- a/backend/routes/recall.py
+++ b/backend/routes/recall.py
@@ -12,7 +12,9 @@ recall_bp = Blueprint('recall', __name__)
 
 
 def log_event(session: Session, event_type: str, details: str):
-    log = AuditLog(event_type=event_type, details=details)
+    username = getattr(request, 'user', {}).get('username') if hasattr(request, 'user') else None
+    role = getattr(request, 'user', {}).get('role') if hasattr(request, 'user') else None
+    log = AuditLog(event_type=event_type, details=details, username=username, role=role)
     session.add(log)
     session.commit()
 

--- a/frontend/cfa.html
+++ b/frontend/cfa.html
@@ -1535,11 +1535,13 @@
         }
 
         // Load Pack Configs (View Only for CFA)
-        function loadCFAPackConfigs() {
+        async function loadCFAPackConfigs() {
             const body = document.getElementById('cfaPackConfigTableBody');
             if (!body) return;
             body.innerHTML = '';
-            dummyCFAData.packConfigs.forEach(c => {
+            const resp = await fetch('/api/pack-configs', { headers: { 'Authorization': `Bearer ${token}` } });
+            const data = resp.ok ? await resp.json() : [];
+            data.forEach(c => {
                 const row = document.createElement('tr');
                 row.innerHTML = `
                     <td>${c.id}</td>
@@ -1640,18 +1642,20 @@
         }
 
         // Load CFA's Own Stock
-        function loadCFAMyStock() {
+        async function loadCFAMyStock() {
             const body = document.getElementById('cfaMyStockTableBody');
             if (!body) return;
             body.innerHTML = '';
-            dummyCFAData.cfaMyStock.forEach(s => {
+            const resp = await fetch('/api/inventory', { headers: { 'Authorization': `Bearer ${token}` } });
+            const data = resp.ok ? await resp.json() : [];
+            data.forEach(s => {
                 const row = document.createElement('tr');
                 row.innerHTML = `
-                    <td>${s.product_name}</td>
+                    <td>${s.product_name || s.product_id}</td>
                     <td>${s.batch_no}</td>
                     <td>${s.quantity}</td>
                     <td>${s.exp_date || ''}</td>
-                    <td>${s.last_updated || ''}</td>
+                    <td>${s.mfg_date || ''}</td>
                     <td class="action-buttons">
                         <button class="btn btn-secondary btn-sm"><i class="fas fa-edit"></i> Adjust</button>
                     </td>
@@ -1661,48 +1665,51 @@
         }
 
         // Load Downstream Stockist Visibility (CFA can see SS stock)
-        function loadDownstreamStockVisibility() {
-            // This would fetch from a combined inventory view or iterate through SS entities
-            // For now, using hardcoded dummy data for demonstration
+        async function loadDownstreamStockVisibility() {
             const body = document.getElementById('downstreamStockTableBody');
             if (!body) return;
             body.innerHTML = '';
-            const dummyDownstreamStock = [
-                { stockist: 'SS001 - Delhi', product_name: 'Paracetamol 500mg', batch_no: 'B001XYZ', quantity: 500, exp_date: '2026-01-14', status: 'Healthy' },
-                { stockist: 'SS002 - Chennai', product_name: 'Amoxicillin 250mg', batch_no: 'B003ABC', quantity: 50, exp_date: '2025-07-30', status: 'Low Stock' },
-                { stockist: 'SS001 - Delhi', product_name: 'Antacid Liquid', batch_no: 'B004JKL', quantity: 120, exp_date: '2025-11-15', status: 'Healthy' }
-            ];
-            dummyDownstreamStock.forEach(s => {
+            const stockists = ['SS001', 'SS002'];
+            const allData = [];
+            await Promise.all(stockists.map(async id => {
+                const resp = await fetch(`/api/inventory?location=${id}`, { headers: { 'Authorization': `Bearer ${token}` } });
+                if (resp.ok) {
+                    const rows = await resp.json();
+                    rows.forEach(r => allData.push({ stockist: id, ...r }));
+                }
+            }));
+            allData.forEach(s => {
                 const row = document.createElement('tr');
-                let statusColor = 'inherit';
-                if (s.status === 'Low Stock') statusColor = '#ffc107';
+                let statusColor = s.low_stock ? '#ffc107' : 'inherit';
                 row.innerHTML = `
                     <td>${s.stockist}</td>
-                    <td>${s.product_name}</td>
+                    <td>${s.product_name || s.product_id}</td>
                     <td>${s.batch_no}</td>
                     <td>${s.quantity}</td>
                     <td>${s.exp_date || ''}</td>
-                    <td style="color:${statusColor}; font-weight: 500;">${s.status}</td>
+                    <td style="color:${statusColor}; font-weight: 500;">${s.low_stock ? 'Low Stock' : 'Healthy'}</td>
                 `;
                 body.appendChild(row);
             });
         }
 
         // Load Audit Logs for CFA
-        function loadCFAAuditLogs() {
+        async function loadCFAAuditLogs() {
             const body = document.getElementById('cfaAuditLogTableBody');
             if (!body) return;
             body.innerHTML = '';
-            dummyCFAData.auditLogs.forEach(log => {
+            const resp = await fetch('/api/audit-logs?role=cfa', { headers: { 'Authorization': `Bearer ${token}` } });
+            const data = resp.ok ? await resp.json() : [];
+            data.forEach(log => {
                 const row = document.createElement('tr');
                 row.innerHTML = `
                     <td>${log.timestamp}</td>
-                    <td>${log.user}</td>
-                    <td>${log.action}</td>
-                    <td>${log.entity}</td>
-                    <td>${log.entity_id}</td>
+                    <td>${log.username || ''}</td>
+                    <td>${log.event_type}</td>
+                    <td></td>
+                    <td></td>
                     <td>${log.details}</td>
-                    <td>${log.ip_address}</td>
+                    <td></td>
                 `;
                 body.appendChild(row);
             });
@@ -1731,25 +1738,44 @@
             closeModal('placeMfrOrderModal');
         });
 
-        document.getElementById('receiveStockForm').addEventListener('submit', function(e) {
+        document.getElementById('receiveStockForm').addEventListener('submit', async function(e) {
             e.preventDefault();
             const productId = document.getElementById('receiveProductId').value;
             const batchNo = document.getElementById('receiveBatchNo').value;
-            const quantity = document.getElementById('receiveQuantity').value;
-            alert(`Received Stock: Product ${productId}, Batch ${batchNo}, Quantity ${quantity} (Simulated)`);
+            const quantity = parseInt(document.getElementById('receiveQuantity').value);
+            const expDate = document.getElementById('receiveExpDate').value;
+            await fetch('/api/inventory', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+                body: JSON.stringify({ product_id: productId, batch_no: batchNo, quantity, exp_date: expDate })
+            });
+            await fetch('/api/cfa/stock', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+                body: JSON.stringify({ product_id: productId, batch_no: batchNo, quantity, action: 'received' })
+            });
+            await loadCFAMyStock();
             closeModal('cfaAddStockModal');
-            // In real app: update cfaMyStock and refresh
         });
 
-        document.getElementById('dispatchStockForm').addEventListener('submit', function(e) {
+        document.getElementById('dispatchStockForm').addEventListener('submit', async function(e) {
             e.preventDefault();
             const productId = document.getElementById('dispatchProductId').value;
             const batchNo = document.getElementById('dispatchBatchNo').value;
-            const quantity = document.getElementById('dispatchQuantity').value;
+            const quantity = parseInt(document.getElementById('dispatchQuantity').value);
             const stockistId = document.getElementById('dispatchToStockistId').value;
-            alert(`Dispatched Stock: Product ${productId}, Batch ${batchNo}, Quantity ${quantity} to ${stockistId} (Simulated)`);
+            await fetch('/api/inventory', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+                body: JSON.stringify({ product_id: productId, batch_no: batchNo, quantity, location: stockistId })
+            });
+            await fetch('/api/cfa/stock', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+                body: JSON.stringify({ product_id: productId, batch_no: batchNo, quantity, action: 'dispatched' })
+            });
+            await loadCFAMyStock();
             closeModal('cfaDispatchStockModal');
-            // In real app: update cfaMyStock and SS stock, refresh
         });
 
 

--- a/frontend/manufacterer.html
+++ b/frontend/manufacterer.html
@@ -1868,7 +1868,7 @@
                 units_per_pack: document.getElementById('unitsPerPack').value,
                 dimensions: document.getElementById('packDimensions').value
             };
-            const resp = await fetch('/api/manufacturer/pack-configs', {
+            const resp = await fetch('/api/pack-configs', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
                 body: JSON.stringify(payload)
@@ -1888,7 +1888,7 @@
                 units_per_pack: document.getElementById('editUnitsPerPack').value,
                 dimensions: document.getElementById('editPackDimensions').value
             };
-            const resp = await fetch(`/api/manufacturer/pack-configs/${id}`, {
+            const resp = await fetch(`/api/pack-configs/${id}`, {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
                 body: JSON.stringify(payload)
@@ -1935,7 +1935,7 @@
         }
 
         async function loadPackConfigs() {
-            const resp = await fetch('/api/manufacturer/pack-configs', { headers: { 'Authorization': `Bearer ${token}` } });
+            const resp = await fetch('/api/pack-configs', { headers: { 'Authorization': `Bearer ${token}` } });
             const data = await resp.json();
             const body = document.getElementById('packConfigTableBody');
             body.innerHTML = '';
@@ -1958,7 +1958,7 @@
                 delBtn.innerHTML = '<i class="fas fa-trash-alt"></i> Delete';
                 delBtn.addEventListener('click', async () => {
                     if (confirm('Delete config?')) {
-                        await fetch(`/api/manufacturer/pack-configs/${c.id}`, { method: 'DELETE', headers: { 'Authorization': `Bearer ${token}` } });
+                        await fetch(`/api/pack-configs/${c.id}`, { method: 'DELETE', headers: { 'Authorization': `Bearer ${token}` } });
                         await loadPackConfigs();
                     }
                 });
@@ -2109,7 +2109,7 @@
         }
 
         async function loadAuditLogs() {
-            const resp = await fetch('/api/audit-logs', { headers: { 'Authorization': `Bearer ${token}` } });
+            const resp = await fetch('/api/audit-logs?role=manufacturer', { headers: { 'Authorization': `Bearer ${token}` } });
             if (!resp.ok) return;
             const data = await resp.json();
             const body = document.getElementById('auditLogTableBody');

--- a/frontend/stockist.html
+++ b/frontend/stockist.html
@@ -1334,18 +1334,20 @@
         }
 
         // Load Batch Information (View Only for Stockist)
-        function loadStockistBatches() {
+        async function loadStockistBatches() {
             const body = document.getElementById('stockistBatchTableBody');
             if (!body) return;
             body.innerHTML = '';
-            dummyStockistData.batches.forEach(b => {
+            const resp = await fetch('/api/batches', { headers: { 'Authorization': `Bearer ${token}` } });
+            const data = resp.ok ? await resp.json() : [];
+            data.forEach(b => {
                 const row = document.createElement('tr');
                 row.innerHTML = `
                     <td>${b.id}</td>
                     <td>${b.product_id}</td>
                     <td>${b.mfg_date || ''}</td>
                     <td>${b.exp_date || ''}</td>
-                    <td>${b.mrp.toFixed(2) || ''}</td>
+                    <td>${b.mrp ? b.mrp.toFixed(2) : ''}</td>
                     <td>${b.quantity || ''}</td>
                 `;
                 body.appendChild(row);
@@ -1434,20 +1436,22 @@
         }
 
         // Load Audit Logs for Stockist
-        function loadStockistAuditLogs() {
+        async function loadStockistAuditLogs() {
             const body = document.getElementById('stockistAuditLogTableBody');
             if (!body) return;
             body.innerHTML = '';
-            dummyStockistData.auditLogs.forEach(log => {
+            const resp = await fetch('/api/audit-logs?role=super_stockist', { headers: { 'Authorization': `Bearer ${token}` } });
+            const data = resp.ok ? await resp.json() : [];
+            data.forEach(log => {
                 const row = document.createElement('tr');
                 row.innerHTML = `
                     <td>${log.timestamp}</td>
-                    <td>${log.user}</td>
-                    <td>${log.action}</td>
-                    <td>${log.entity}</td>
-                    <td>${log.entity_id}</td>
+                    <td>${log.username || ''}</td>
+                    <td>${log.event_type}</td>
+                    <td></td>
+                    <td></td>
                     <td>${log.details}</td>
-                    <td>${log.ip_address}</td>
+                    <td></td>
                 `;
                 body.appendChild(row);
             });


### PR DESCRIPTION
## Summary
- update manufacturer pack-config calls to unified endpoint and filter audit logs
- fetch pack configs in CFA dashboard from new route
- record CFA stock movements and update inventory via API
- show downstream stock from API data
- use API data for stockist batches and audit logs

## Testing
- `pip install -r backend/requirements.txt`
- `PORT=8001 nohup python main.py` *(server started)*
- `curl -X POST http://127.0.0.1:8001/api/auth/login -H 'Content-Type: application/json' -d '{"username":"admin","password":"adminpass"}'`
- `pytest tests` *(fails: tests directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68570ce70270832a83ee9f618b2070a7