### PR TITLE
[Backend] Add analytics routes and integrate charts

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -14,6 +14,7 @@ from backend.routes.pricing import pricing_bp
 from backend.routes.recall import recall_bp
 from backend.routes.pack_config import pack_config_bp
 from backend.routes.cfa_stock import cfa_stock_bp
+from backend.routes.analytics import analytics_bp
 from backend.database import engine, SessionLocal
 from backend.models import Base
 from backend.models.order import Order  # ensure table registration
@@ -90,6 +91,7 @@ app.register_blueprint(pricing_bp, url_prefix="/api")
 app.register_blueprint(recall_bp, url_prefix="/api")
 app.register_blueprint(pack_config_bp, url_prefix="/api")
 app.register_blueprint(cfa_stock_bp, url_prefix="/api")
+app.register_blueprint(analytics_bp, url_prefix="/api")
 
 
 @app.route("/")

--- a/backend/routes/analytics.py
+++ b/backend/routes/analytics.py
@@ -1,0 +1,71 @@
+from flask import Blueprint, jsonify, request
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+from backend.auth import roles_required, role_required
+from backend.database import SessionLocal
+from backend.models.order import Order
+from backend.models.inventory import Inventory
+from backend.models.product import Product
+
+analytics_bp = Blueprint('analytics', __name__)
+
+@analytics_bp.route('/analytics/order-stats', methods=['GET'])
+@roles_required('manufacturer', 'cfa', 'super_stockist')
+def order_stats():
+    session: Session = SessionLocal()
+    rows = session.query(Order.status, func.count(Order.id)).group_by(Order.status).all()
+    result = {status: count for status, count in rows}
+    session.close()
+    return jsonify(result)
+
+@analytics_bp.route('/analytics/low-stock', methods=['GET'])
+@roles_required('manufacturer', 'cfa', 'super_stockist')
+def low_stock():
+    session: Session = SessionLocal()
+    threshold = int(request.args.get('threshold', 50))
+    query = session.query(Inventory, Product.name).join(Product, Inventory.product_id == Product.id)
+    query = query.filter(Inventory.quantity < threshold)
+    if request.user['role'] in ('cfa', 'super_stockist'):
+        query = query.filter(Inventory.location == request.user['username'])
+    rows = query.all()
+    result = [
+        {
+            'product_name': name,
+            'location': inv.location,
+            'quantity': inv.quantity
+        }
+        for inv, name in rows
+    ]
+    session.close()
+    return jsonify(result)
+
+@analytics_bp.route('/analytics/refill-suggestions', methods=['GET'])
+@roles_required('manufacturer', 'cfa', 'super_stockist')
+def refill_suggestions():
+    session: Session = SessionLocal()
+    query = session.query(Inventory, Product.name).join(Product, Inventory.product_id == Product.id)
+    if request.user['role'] in ('cfa', 'super_stockist'):
+        query = query.filter(Inventory.location == request.user['username'])
+    rows = query.all()
+    suggestions = []
+    for inv, name in rows:
+        if inv.quantity < 30:
+            suggestions.append({'product_name': name, 'suggested_qty': 100 - inv.quantity})
+    session.close()
+    return jsonify(suggestions)
+
+@analytics_bp.route('/analytics/my-sales', methods=['GET'])
+@role_required('super_stockist')
+def my_sales():
+    session: Session = SessionLocal()
+    orders = session.query(Order).filter_by(placed_by=request.user['username'], status='acknowledged').all()
+    stats = {}
+    for o in orders:
+        if o.order_date:
+            key = o.order_date.strftime('%Y-%m')
+        else:
+            key = 'unknown'
+        stats[key] = stats.get(key, 0) + o.quantity
+    result = [{'month': k, 'sales': v} for k, v in sorted(stats.items())]
+    session.close()
+    return jsonify(result)

--- a/frontend/cfa.html
+++ b/frontend/cfa.html
@@ -810,7 +810,7 @@
                         </div>
                         <div class="dashboard-card alert-card warning">
                             <span class="alert-icon"><i class="fas fa-exclamation-triangle"></i></span>
-                            <p><strong>Alert:</strong> Low stock for **Product Y** (Batch B123) - only 50 units left. Consider ordering from Manufacturer.</p>
+                            <p id="refillAlert"><strong>Alert:</strong> Low stock for **Product Y** (Batch B123) - only 50 units left. Consider ordering from Manufacturer.</p>
                         </div>
                         <div class="dashboard-card chart-card">
                             <div class="card-header">
@@ -1114,6 +1114,16 @@
                 </div>
             </section>
 
+            <section id="qr-scanner-section" class="content-section">
+                <div class="card">
+                    <div class="card-header">
+                        <h3>QR Code Scanner</h3>
+                    </div>
+                    <button class="btn btn-primary" id="startScanBtn"><i class="fas fa-qrcode"></i> Scan</button>
+                    <div id="qrReader" style="width:300px; display:none;"></div>
+                </div>
+            </section>
+
             <section id="audit-trail-section" class="content-section">
                 <div class="card">
                     <div class="card-header">
@@ -1282,8 +1292,7 @@
             <span>Audit</span>
         </a>
     </nav>
-
-
+    <script src="https://unpkg.com/html5-qrcode@2.3.8/html5-qrcode.min.js"></script>
     <script>
         // Basic JS for sidebar navigation and modal placeholders
         document.addEventListener('DOMContentLoaded', function () {
@@ -1405,8 +1414,10 @@
             loadIncomingOrders();
             loadOutgoingOrders();
             loadCFAMyStock();
+            loadRefillSuggestions();
             loadDownstreamStockVisibility();
             loadCFAAuditLogs();
+            renderCFACharts();
             populateProductDropdownsCFA();
             document.getElementById('pricingStateRegionCFA').addEventListener('change', loadCFAPricing);
         });
@@ -1778,27 +1789,45 @@
             closeModal('cfaDispatchStockModal');
         });
 
+        async function loadRefillSuggestions() {
+            const resp = await fetch('/api/analytics/refill-suggestions', { headers: { 'Authorization': `Bearer ${token}` } });
+            const data = resp.ok ? await resp.json() : [];
+            const alertP = document.getElementById('refillAlert');
+            if (alertP) {
+                if (data.length > 0) {
+                    const s = data[0];
+                    alertP.innerHTML = `<strong>Alert:</strong> Low stock for <b>${s.product_name}</b> - order ${s.suggested_qty} units.`;
+                } else {
+                    alertP.textContent = 'Stock levels are healthy.';
+                }
+            }
+        }
+
+        document.getElementById('startScanBtn').addEventListener('click', function() {
+            const qrDiv = document.getElementById('qrReader');
+            qrDiv.style.display = 'block';
+            const scanner = new Html5Qrcode('qrReader');
+            scanner.start({ facingMode: 'environment' }, { fps: 10, qrbox: 250 }, (decodedText) => {
+                alert('QR: ' + decodedText);
+                scanner.stop();
+                qrDiv.style.display = 'none';
+            });
+        });
+
 
 
         // Placeholder for chart rendering on CFA dashboard
-        function renderCFACharts() {
-            // Simulate data for dashboard charts
+        async function renderCFACharts() {
             const incomingOrdersCtx = document.getElementById('incomingOrdersChart');
             if (incomingOrdersCtx) {
-                const incomingOrdersData = {
-                    labels: ['Week 1', 'Week 2', 'Week 3', 'Week 4'],
-                    datasets: [{
-                        label: 'Incoming Orders Volume',
-                        data: [15, 20, 10, 25],
-                        backgroundColor: 'rgba(52, 152, 219, 0.7)',
-                        borderColor: 'rgba(52, 152, 219, 1)',
-                        borderWidth: 1,
-                        borderRadius: 4
-                    }]
-                };
+                const resp = await fetch('/api/analytics/order-stats', { headers: { 'Authorization': `Bearer ${token}` } });
+                const stats = resp.ok ? await resp.json() : {};
                 new Chart(incomingOrdersCtx, {
                     type: 'bar',
-                    data: incomingOrdersData,
+                    data: {
+                        labels: Object.keys(stats),
+                        datasets: [{ label: 'Orders', data: Object.values(stats), backgroundColor: 'rgba(52,152,219,0.7)' }]
+                    },
                     options: { responsive: true, maintainAspectRatio: false, scales: { y: { beginAtZero: true } }, plugins: { legend: { display: false } } }
                 });
             }
@@ -1812,7 +1841,6 @@
             document.getElementById('cfa-stock-value').textContent = `$${totalStockValue.toFixed(2)}`;
         }
 
-        document.addEventListener('DOMContentLoaded', renderCFACharts); // Render charts after all content is loaded
     </script>
 </body>
 </html>

--- a/frontend/manufacterer.html
+++ b/frontend/manufacterer.html
@@ -1552,8 +1552,7 @@
             <span>Users</span>
         </a>
     </nav>
-
-
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.umd.min.js"></script>
     <script>
         // Basic JS for sidebar navigation and modal placeholders
         document.addEventListener('DOMContentLoaded', function () {
@@ -1716,9 +1715,37 @@
             //     options: { responsive: true, maintainAspectRatio: false }
             // });
         }
+        async function loadAnalytics() {
+            const salesCtx = document.getElementById('salesChart');
+            const resp = await fetch('/api/analytics/order-stats', { headers: { 'Authorization': `Bearer ${token}` } });
+            const data = resp.ok ? await resp.json() : {};
+            if (salesCtx) {
+                new Chart(salesCtx, {
+                    type: 'bar',
+                    data: {
+                        labels: Object.keys(data),
+                        datasets: [{ label: 'Orders', data: Object.values(data), backgroundColor: '#3498db' }]
+                    },
+                    options: { responsive: true, maintainAspectRatio: false, scales: { y: { beginAtZero: true } } }
+                });
+            }
+            const heatCtx = document.getElementById('lowStockHeatmap');
+            const resp2 = await fetch('/api/analytics/low-stock', { headers: { 'Authorization': `Bearer ${token}` } });
+            const d2 = resp2.ok ? await resp2.json() : [];
+            if (heatCtx && heatCtx.getContext) {
+                const ctx = heatCtx.getContext('2d');
+                new Chart(ctx, {
+                    type: 'bar',
+                    data: {
+                        labels: d2.map(i => i.product_name),
+                        datasets: [{ label: 'Qty', data: d2.map(i => i.quantity), backgroundColor: 'rgba(231,76,60,0.7)' }]
+                    },
+                    options: { responsive: true, maintainAspectRatio: false, scales: { y: { beginAtZero: true } } }
+                });
+            }
+        }
         renderCharts();
-
-        const token = localStorage.getItem('token');
+        loadAnalytics();
 
         async function loadProducts() {
             const resp = await fetch('/api/manufacturer/products', {

--- a/frontend/stockist.html
+++ b/frontend/stockist.html
@@ -1221,6 +1221,7 @@
             loadStockistBatches();
             loadStockistPricing();
             fetchMyStock();
+            fetchSalesData();
             loadStockistAuditLogs();
             document.getElementById('pricingStateRegionStockist').addEventListener('change', loadStockistPricing);
         });
@@ -1297,6 +1298,11 @@
             } else {
                 alertBox.style.display = 'none';
             }
+        }
+
+        async function fetchSalesData() {
+            const resp = await fetch('/api/analytics/my-sales', { headers: { 'Authorization': `Bearer ${token}` } });
+            dummyStockistData.mySales = resp.ok ? await resp.json() : [];
         }
 
         // Populate dropdowns with products for order placement
@@ -1482,9 +1488,7 @@
 
 
 
-        // Placeholder for chart rendering on Stockist dashboard
-        function renderStockistCharts() {
-            // Simulate data for dashboard charts
+        async function renderStockistCharts() {
             const stockistSalesCtx = document.getElementById('stockistSalesChart');
             if (stockistSalesCtx) {
                 const salesData = dummyStockistData.mySales;
@@ -1514,7 +1518,7 @@
             document.getElementById('stockist-stock-value').textContent = `$${totalStockValue.toFixed(2)}`;
         }
 
-        document.addEventListener('DOMContentLoaded', renderStockistCharts); // Render charts after all content is loaded
+        document.addEventListener('DOMContentLoaded', async () => { await fetchSalesData(); renderStockistCharts(); });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement analytics routes for orders, low stock, refill suggestions, and sales
- register analytics blueprint
- display BI charts on manufacturer dashboard
- add refill suggestion alerts and QR code scanner for CFA dashboard
- fetch sales data for stockist charts

## Testing
- `python main.py`
- `pytest tests/` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857251f2118832a976c43915a19ff47