### PR TITLE
[Backend] Add stock point assignment API

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -16,6 +16,7 @@ from backend.routes.pack_config import pack_config_bp
 from backend.routes.cfa_stock import cfa_stock_bp
 from backend.routes.analytics import analytics_bp
 from backend.routes.offer import offer_bp
+from backend.routes.stock_point import stock_point_bp
 from backend.database import engine, SessionLocal
 from backend.models import Base
 from backend.models.order import Order  # ensure table registration
@@ -29,6 +30,7 @@ from backend.models.audit_log import AuditLog
 from backend.models.recall import Recall
 from backend.models.cfa_stock_movement import CFAStockMovement
 from backend.models.offer import Offer
+from backend.models.stock_point import StockPoint
 
 app = Flask(__name__, static_folder="../frontend", static_url_path="")
 
@@ -95,6 +97,7 @@ app.register_blueprint(pack_config_bp, url_prefix="/api")
 app.register_blueprint(cfa_stock_bp, url_prefix="/api")
 app.register_blueprint(analytics_bp, url_prefix="/api")
 app.register_blueprint(offer_bp, url_prefix="/api")
+app.register_blueprint(stock_point_bp, url_prefix="/api/manufacturer")
 
 
 @app.route("/")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -6,4 +6,5 @@ from .pricing_catalog import PricingCatalog
 from .recall import Recall
 from .cfa_stock_movement import CFAStockMovement
 from .offer import Offer
+from .stock_point import StockPoint
 

--- a/backend/models/stock_point.py
+++ b/backend/models/stock_point.py
@@ -1,0 +1,9 @@
+from sqlalchemy import Column, Integer, String, ForeignKey
+from . import Base
+
+class StockPoint(Base):
+    __tablename__ = 'stock_points'
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    cfa_username = Column(String, ForeignKey('users.username'), nullable=False)
+    active = Column(Integer, default=1)

--- a/backend/routes/stock_point.py
+++ b/backend/routes/stock_point.py
@@ -1,0 +1,87 @@
+from flask import Blueprint, request, jsonify
+from sqlalchemy.orm import Session
+from backend.auth import role_required
+from backend.database import SessionLocal
+from backend.models.stock_point import StockPoint
+from backend.models.audit_log import AuditLog
+
+stock_point_bp = Blueprint('stock_point', __name__)
+
+
+def log_event(session: Session, event_type: str, details: str):
+    username = getattr(request, 'user', {}).get('username') if hasattr(request, 'user') else None
+    role = getattr(request, 'user', {}).get('role') if hasattr(request, 'user') else None
+    log = AuditLog(event_type=event_type, details=details, username=username, role=role)
+    session.add(log)
+    session.commit()
+
+
+@stock_point_bp.route('/stock-points', methods=['GET', 'POST'])
+@role_required('manufacturer')
+def manage_stock_points():
+    session: Session = SessionLocal()
+    if request.method == 'POST':
+        data = request.json or {}
+        name = data.get('name')
+        cfa_username = data.get('cfa_username')
+        if not name or not cfa_username:
+            session.close()
+            return jsonify({'error': 'Invalid stock point data'}), 400
+        record = StockPoint(name=name, cfa_username=cfa_username, active=1)
+        session.add(record)
+        session.commit()
+        log_event(session, 'stock_point_created', f'{name} assigned to {cfa_username}')
+        result = {
+            'id': record.id,
+            'name': record.name,
+            'cfa_username': record.cfa_username,
+            'active': record.active,
+        }
+        session.close()
+        return jsonify(result), 201
+
+    records = session.query(StockPoint).all()
+    result = [
+        {
+            'id': r.id,
+            'name': r.name,
+            'cfa_username': r.cfa_username,
+            'active': r.active,
+        }
+        for r in records
+    ]
+    session.close()
+    return jsonify(result)
+
+
+@stock_point_bp.route('/stock-points/<int:sp_id>', methods=['PUT', 'DELETE'])
+@role_required('manufacturer')
+def modify_stock_point(sp_id: int):
+    session: Session = SessionLocal()
+    sp = session.query(StockPoint).get(sp_id)
+    if not sp:
+        session.close()
+        return jsonify({'error': 'Stock point not found'}), 404
+    if request.method == 'DELETE':
+        session.delete(sp)
+        session.commit()
+        log_event(session, 'stock_point_deleted', f'{sp_id} deleted')
+        session.close()
+        return jsonify({'message': 'deleted'})
+    data = request.json or {}
+    if 'name' in data:
+        sp.name = data['name']
+    if 'cfa_username' in data:
+        sp.cfa_username = data['cfa_username']
+    if 'active' in data:
+        sp.active = data['active']
+    session.commit()
+    log_event(session, 'stock_point_updated', f'{sp_id} updated')
+    result = {
+        'id': sp.id,
+        'name': sp.name,
+        'cfa_username': sp.cfa_username,
+        'active': sp.active,
+    }
+    session.close()
+    return jsonify(result)

--- a/frontend/manufacterer.html
+++ b/frontend/manufacterer.html
@@ -1550,9 +1550,21 @@
     </div>
     <div id="assignCfaModal" class="modal">
         <div class="modal-content">
-            <div class="modal-header"><h3>Assign CFA / Activate Stock Point</h3><span class="close-btn" onclick="closeModal('assignCfaModal')">&times;</span></div>
-            <p>Form for assigning CFA goes here...</p>
-            <div class="modal-footer"><button type="button" class="btn btn-secondary" onclick="closeModal('assignCfaModal')">Cancel</button><button type="submit" class="btn btn-success">Assign</button></div>
+            <form id="assignCfaForm">
+                <div class="modal-header"><h3>Assign CFA / Activate Stock Point</h3><span class="close-btn" onclick="closeModal('assignCfaModal')">&times;</span></div>
+                <div class="form-group">
+                    <label for="stockPointName">Stock Point Name:</label>
+                    <input type="text" id="stockPointName" required>
+                </div>
+                <div class="form-group">
+                    <label for="cfaUsername">CFA Username:</label>
+                    <input type="text" id="cfaUsername" required>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" onclick="closeModal('assignCfaModal')">Cancel</button>
+                    <button type="submit" class="btn btn-success">Assign</button>
+                </div>
+            </form>
         </div>
     </div>
     <div id="addUserModal" class="modal">
@@ -2153,6 +2165,7 @@
         loadOrders();
         loadLiveStock();
         loadUsers();
+        loadStockPoints();
         loadAuditLogs();
         loadRecalls();
         loadOffers();
@@ -2211,6 +2224,27 @@
                     <td>${u.role}</td>
                     <td>Active</td>
                     <td></td>
+                    <td></td>`;
+                body.appendChild(row);
+            });
+        }
+
+        async function loadStockPoints() {
+            const resp = await fetch('/api/manufacturer/stock-points', { headers: { 'Authorization': `Bearer ${token}` } });
+            if (!resp.ok) return;
+            const data = await resp.json();
+            const body = document.getElementById('cfaTableBody');
+            if (!body) return;
+            body.innerHTML = '';
+            data.forEach(s => {
+                const row = document.createElement('tr');
+                row.innerHTML = `
+                    <td>${s.id}</td>
+                    <td>${s.cfa_username}</td>
+                    <td>${s.name}</td>
+                    <td>${s.active ? 'Active' : 'Inactive'}</td>
+                    <td>Yes</td>
+                    <td>Yes</td>
                     <td></td>`;
                 body.appendChild(row);
             });
@@ -2312,6 +2346,24 @@
                 body.appendChild(row);
             });
         }
+
+        document.getElementById('assignCfaForm').addEventListener('submit', async function(e) {
+            e.preventDefault();
+            const payload = {
+                name: document.getElementById('stockPointName').value,
+                cfa_username: document.getElementById('cfaUsername').value
+            };
+            const resp = await fetch('/api/manufacturer/stock-points', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+                body: JSON.stringify(payload)
+            });
+            if (resp.ok) {
+                document.getElementById('assignCfaForm').reset();
+                closeModal('assignCfaModal');
+                await loadStockPoints();
+            }
+        });
 
     </script>
 </body>


### PR DESCRIPTION
## Summary
- implement StockPoint model and CRUD routes
- wire StockPoint blueprint in the Flask app
- enhance manufacturer dashboard to assign CFAs to stock points

## Testing
- `pip install -r backend/requirements.txt`
- `PORT=8001 python main.py` *(fails: Address already in use or process stops)*


------
https://chatgpt.com/codex/tasks/task_e_68572b7361c0832aa0411f46828440e5